### PR TITLE
Updating TLS secrets

### DIFF
--- a/user/pages/03.configuration/01.console/01.replacecert/docs.md
+++ b/user/pages/03.configuration/01.console/01.replacecert/docs.md
@@ -52,7 +52,7 @@ spec:
         - mountPath: /etc/neuvector/certs/ssl-cert.pem
           name: cert
           readOnly: true
-          subPath: tls.pem
+          subPath: tls.crt
       volumes:
       - name: cert
         secret:

--- a/user/pages/03.configuration/01.console/01.replacecert/docs.md
+++ b/user/pages/03.configuration/01.console/01.replacecert/docs.md
@@ -83,5 +83,4 @@ controller:
     keyFile: tls.key
     pemFile: tls.crt
 ```
-Then update with `helm upgrade -i neuvector ...`
-For reference here are all the values https://github.com/neuvector/neuvector-helm/blob/5.0.0/charts/core/values.yaml
+Then update with `helm upgrade -i neuvector ...`. For reference here are all the values https://github.com/neuvector/neuvector-helm/tree/master/charts/core.

--- a/user/pages/03.configuration/01.console/01.replacecert/docs.md
+++ b/user/pages/03.configuration/01.console/01.replacecert/docs.md
@@ -38,7 +38,7 @@ DNS.1 = *
 ```
 kubectl create secret tls https-cert -n neuvector --from-file=tls.key --from-file=tls.crt
 ```
-3. Edit the yaml for the manager and controller deployments to add the mounts
+3. Edit the yaml direclty for the manager and controller deployments to add the mounts
 ```
 spec:
   template:
@@ -59,7 +59,7 @@ spec:
           defaultMode: 420
           secretName: https-cert
 ```
-Or update with the helm chart with similar values
+Or update with the helm chart with similar values.yaml
 ```
 manager:
   certificate:
@@ -83,4 +83,5 @@ controller:
     keyFile: tls.key
     pemFile: tls.crt
 ```
-then update with `helm upgrade -i neuvector ...`
+Then update with `helm upgrade -i neuvector ...`
+For reference here are all the values https://github.com/neuvector/neuvector-helm/blob/5.0.0/charts/core/values.yaml

--- a/user/pages/03.configuration/01.console/01.replacecert/docs.md
+++ b/user/pages/03.configuration/01.console/01.replacecert/docs.md
@@ -36,7 +36,7 @@ DNS.1 = *
 ```
 2. Create the secret from the generated key and certificate files from above
 ```
-kubectl create secret tls https-cert -n neuvector --from-file=tls.key --from-file=tls.crt
+kubectl create secret tls https-cert -n neuvector --key=tls.key --cert=tls.crt
 ```
 3. Edit the yaml direclty for the manager and controller deployments to add the mounts
 ```

--- a/user/pages/03.configuration/01.console/01.replacecert/docs.md
+++ b/user/pages/03.configuration/01.console/01.replacecert/docs.md
@@ -38,7 +38,7 @@ DNS.1 = *
 ```
 kubectl create secret tls https-cert -n neuvector --key=tls.key --cert=tls.crt
 ```
-3. Edit the yaml direclty for the manager and controller deployments to add the mounts
+3. Edit the yaml directly for the manager and controller deployments to add the mounts
 ```
 spec:
   template:


### PR DESCRIPTION
Upgrading the secret to a tls one instead of generic. This does require the pem to renamed crt. 
Also adding helm values to update the manager and controller.