### PR TITLE
Update docs.md

### DIFF
--- a/user/pages/02.deploying/03.rancher/docs.md
+++ b/user/pages/02.deploying/03.rancher/docs.md
@@ -16,7 +16,7 @@ First, find the NeuVector chart in Rancher charts, select it and review the inst
 ![rancher_chart](rancher_chart.png)
 
 Deploy the NeuVector chart, first configuring appropriate values for a Rancher deployment, such as:
-+ Container run-time, e.g. docker for RKE and containerd for RKE2, or select the K3s value if using K3s.
++ Container run-time, e.g. docker for RKE, or select the K3s value if using RKE2 or K3s.
 + Manager service type: change to LoadBalancer if available on public cloud deployments. If access is only desired through Rancher, any allowed value will work here. See the Important note below about changing the default admin password in NeuVector.
 + Indicate if this cluster will be either a multi-cluster federated Primary, or remote (or select both if either option is desired).
 + Persistent volume for configuration backups


### PR DESCRIPTION
Modified container run-time line to show that RKE2 requires the K3s runtime option, not containerd. It will not install on RKE2 with the containerd option.