### PR TITLE
2 typo fixes and alphabetic attack order

### DIFF
--- a/user/pages/05.policy/04.groups/docs.md
+++ b/user/pages/05.policy/04.groups/docs.md
@@ -16,7 +16,7 @@ It is convenient to see groups of containers and apply rules to each group. NeuV
 
 The Groups screen also displays a 'Scorable' icon in the upper right, and a learned group can be selected and the Scorable checkbox enabled or disabled. This controls which containers are used to calculate the Security Risk Score in the Dashboard. See [Improve Security Risk Score](/navigation/improve_score#improving-the-security-risk-score) for more details.
 
-The Groups screen is also where the CRD yaml file for 'security policy as code' can be imported and exported. Select one or more groups and click on the Export Group policy button to download the yaml file. See the [CRD](/policy/usingcrd) section for more details on how to use CRDs. Important: Each selected group AND any linked groups through network rules will be exported (ie. The group and any other group it connects to through the whitelist network rules).
+The Groups screen is also where the CRD yaml file for 'security policy as code' can be imported and exported. Select one or more groups and click on the Export Group policy button to download the yaml file. See the [CRD](/policy/usingcrd) section for more details on how to use CRDs. Important: Each selected group AND any linked groups through network rules will be exported (i.e. the group and any other group it connects to through the whitelist network rules).
 
 <strong>Auto Deletion of Unused Groups</strong>
 Learned groups (not reserved or custom groups) can be automatically deleted by NeuVector if there are no members (containers) in the group. The time period for this is configurable in Settings -> Configuration.

--- a/user/pages/05.policy/05.networkrules/docs.md
+++ b/user/pages/05.policy/05.networkrules/docs.md
@@ -28,7 +28,7 @@ Add a rule using the ‘+’ either below another rule in the right column, or u
 > Specify the destination GROUP where these connections are allowed or denied.
 
 + **Applications**
-> Enter applications for NeuVector to allow or deny. NeuVector understands deep application behavior and will analyze the payload to determine application protocols. Protocols include HTTP, HTTPS, SSL, SSH,DNS, DNCP, NTP, TFTP, ECHO, RTSP, SIP, MySQL, Redis, Zookeeper, Cassandra, MongoDB, PostgresSQL, Kafka, Couchbase, ActiveMQ, ElasticSearch, RabbitMQ, Radius, VoltDB, Consul, Syslog, Etcd, Spark, Apache, Nginx, Jetty, NodeJS, Oracle, MSSQL and gRPC.
+> Enter applications for NeuVector to allow or deny. NeuVector understands deep application behavior and will analyze the payload to determine application protocols. Protocols include HTTP, HTTPS, SSL, SSH, DNS, DNCP, NTP, TFTP, ECHO, RTSP, SIP, MySQL, Redis, Zookeeper, Cassandra, MongoDB, PostgresSQL, Kafka, Couchbase, ActiveMQ, ElasticSearch, RabbitMQ, Radius, VoltDB, Consul, Syslog, Etcd, Spark, Apache, Nginx, Jetty, NodeJS, Oracle, MSSQL and gRPC.
 
 Note: To select Any/All, leave this field blank
 
@@ -68,29 +68,29 @@ Note that customized network threat detection can be configured through the WAF 
 
 NeuVector includes the following detections for threats:
 
-+ SYN flood attack
-+ ICMP flood attack
-+ IP Teardrop attack
-+ TCP split handshake attack
-+ PING death attack 
-+ DNS flood DDOS attack
++ Apache Struts RCE attack
++ Cipher Overflow attack
++ Detect HTTP negative content-length buffer overflow
++ Detect MySQL access deny
 + Detect SSH version 1, 2 or 3
 + Detect SSL TLS v1.0
-+ SSL heartbeed attack
-+ Detect HTTP negative content-length buffer overflow
-+ HTTP smugging attack
-+ HTTP Slowloris DDOS attack
-+ TCP small window attack
 + DNS buffer overflow attack
-+ Detect MySQL access deny
-+ DNS zone transfer attack
-+ ICMP tunneling attack
++ DNS flood DDOS attack
 + DNS null type attack
-+ SQL injection attack
-+ Apache Struts RCE attack
 + DNS tunneling attack
-+ TCP Small MSS attack
-+ Cipher Overflow attack
++ DNS zone transfer attack
++ HTTP Slowloris DDOS attack
++ HTTP smuggling attack
++ ICMP flood attack
++ ICMP tunneling attack
++ IP Teardrop attack
 + Kubernetes man-in-the-middle attack per CVE-2020-8554
++ PING death attack 
++ SQL injection attack
++ SSL heartbleed attack
++ SYN flood attack
++ TCP small window attack
++ TCP split handshake attack
++ TCP Small MSS attack
 
 

--- a/user/pages/05.policy/06.processrules/docs.md
+++ b/user/pages/05.policy/06.processrules/docs.md
@@ -13,7 +13,7 @@ This is the default mode for process and file protections. Zero-drift automatica
 
 The ability to enable/disable zero-drift mode is in the console in Policy -> Groups. Multiple groups can be selected to toggle this setting for all selected groups.
 
-#### Behavioral Learning Based Process ProtectionProcess profile rules use baseline learning to profile the processes that should be allowed to run in a group of containers (ie. a Group). Under normal conditions in a microservices environment, for containers with a particular image, only a limited set of processes by specific users would run. If the container is attacked, the malicious attacker would likely initiate some new programs commonly not seen in this container. These abnormal events can be detected by NeuVector and alerts and actions generated (see also Response Rules).
+#### Behavioral Learning Based Process ProtectionProcess profile rules use baseline learning to profile the processes that should be allowed to run in a group of containers (i.e. a Group). Under normal conditions in a microservices environment, for containers with a particular image, only a limited set of processes by specific users would run. If the container is attacked, the malicious attacker would likely initiate some new programs commonly not seen in this container. These abnormal events can be detected by NeuVector and alerts and actions generated (see also Response Rules).
 Process baseline information will be learned and recorded when the service Group is in Discover (learning) mode. When in Monitor or Protect mode, if a process that has not been seen before is newly started, or an old process is started by a different user than before, the event will be detected and alerted as a suspicious process in Monitor mode or alerted and blocked in Protect mode. Users can modify the learned profile to allow or deny (whitelist or blacklist) processes manually if needed.
 Note that in addition to baseline processes, NeuVector has built-in detection of common suspicious processes such as nmap, reverse shell etc. These will be detected and alerted/blocked unless explicitly white listed for each container service.
 
@@ -33,11 +33,11 @@ Process rules with name and path both containing wildcards take precedence over 
 
 Process rules with a Deny action and wildcard in the name will take precedence over Allow actions with wildcard in the name.
 #### Discover mode+ All new processed are profiled with action allow+ Users can change the action into 'deny' for generating alert or blocking when same new process is started+ Users can create a profile for a process with either allow or deny+ Process profile rules can contain name and/or path
-+ Wildcards &#42; can be used to match all for name or path
++ Wildcard &#42; can be used to match all for name or path
 
-Note:  A suspicious process (built-in detect), such as nmap, ncat. etc., is reported as a suspicious process event and will NOT be learned. If a service needs this process, the process needs to be added with an 'allow' profile rule explicitly.
+Note:  A suspicious process (built-in detect), such as nmap, ncat, etc., is reported as a suspicious process event and will NOT be learned. If a service needs this process, the process needs to be added with an 'allow' profile rule explicitly.
 #### Monitor/Protect mode (new container started in monitor or protect mode)+ Every new process generates an alert+ Process profile rules can contain name and/or path
-+ Wildcards &#42; can be used to match all for name or path
++ Wildcard &#42; can be used to match all for name or path
 
 If a) process matches a deny rule, or b) process is not in the list of allow rules, then:
 + In Monitor mode, alerts will be generated
@@ -50,7 +50,7 @@ Note:  In Protect mode, system containers such as Kubernetes ones, will not enab
 Multiple rules can be created for the same process. The rules are executed sequentially and the first matching rule will be executed.
 + Click Add rule (+) from process profile rules tab
 + Process profile rules can contain name and/or path
-+ Wildcards &#42; can be used to match all for name or path
++ Wildcard &#42; can be used to match all for name or path
 Example:  To allow the ping process to run from any directory 
 ![pingRule](ping.png)
 Violations will be logged in Notifications -> Security Events.![violation](process_event.png)
@@ -84,4 +84,4 @@ In addition the following detections are enabled:
 Suspicious processes are alerted when in Discover or Monitor mode, and blocked when in Protect mode. Detection applies to containers as well as hosts, with the exception of 'sshd' which is not considered suspicious on hosts. Processes listed above can be added to the Allow List for containers (Groups) including hosts if it should be allowed.
 
 ###Split Mode Process/File Protections
-Container Groups can have Process/File rules in a different mode than Network rules, as described [here](/policy/modes#split-policy-mode).
+Container Groups can have Process/File rules in a different mode than Network rules, as described [here](/policy/modes#split-policy-mode).

--- a/user/pages/05.policy/09.dlp/docs.md
+++ b/user/pages/05.policy/09.dlp/docs.md
@@ -18,12 +18,12 @@ WAF sensors represent inspection of network traffic to/from a pod/container. The
 
 This means that, while this feature is named WAF, it is useful and applicable to any network traffic, not only web application traffic, and therefore provides broader protections than simple WAFs. For example, API security can be enforced on outbound connections to an external api service, allowing only GET requests and blocking POSTs. 
 
-Also note that, while similar to DLP, the inspection is for incoming traffic to EVERY pod/container within the group, while DLP applies inspection to incoming and outgoing traffic from the group only (ie the security boundary), not internal traffic in the group (e.g. not east-west within a Group's containers).
+Also note that, while similar to DLP, the inspection is for incoming traffic to EVERY pod/container within the group, while DLP applies inspection to incoming and outgoing traffic from the group only (i.e. the security boundary), not internal traffic in the group (e.g. not east-west within a Group's containers).
 
 ![waf](waf_sensors.png)
 
 #### DLP Sensors
-DLP Sensors are the patterns that are used to inspect traffic. Built in sensors such as credit card and U.S. social security have predefined regular expressions. You can add custom sensors by defining regex patterns to be used in that sensor. Note that, while similar to WAF, DLP applies inspection to incoming and outgoing traffic from the group only (ie the security boundary), not internal traffic in the group (e.g. not east-west within a Group's containers). WAF inspection is for incoming traffic only to EVERY pod/container within the group.
+DLP Sensors are the patterns that are used to inspect traffic. Built in sensors such as credit card and U.S. social security have predefined regular expressions. You can add custom sensors by defining regex patterns to be used in that sensor. Note that, while similar to WAF, DLP applies inspection to incoming and outgoing traffic from the group only (i.e. the security boundary), not internal traffic in the group (e.g. not east-west within a Group's containers). WAF inspection is for incoming traffic only to EVERY pod/container within the group.
 
 ![dlp](sensors.png)
 

--- a/user/pages/05.policy/11.customcompliance/docs.md
+++ b/user/pages/05.policy/11.customcompliance/docs.md
@@ -47,11 +47,11 @@ Other Notes
 
 
 ###Creating a custom check script
-+ Select the service group user created or auto learned group from Policy->Group
++ Select the service group (user created or auto learned) from Policy -> Group.
 + Click custom check tab.
 + Enter name of the script. Spaces are not allowed.
 + Copy and paste script to script section.
-+ Click ADD button to add script
++ Click ADD button to add script.
 + Multiple scripts can be created and managed from the option provided in the right side corner.
 + Scripts are run on the containers covered by the service group as soon as script is created as well as when the script is updated.
 + View the script result from Assets -> Container -> Compliance, or Assets -> Nodes -> Compliance.

--- a/user/pages/05.policy/13.usingcrd/docs.md
+++ b/user/pages/05.policy/13.usingcrd/docs.md
@@ -260,10 +260,10 @@ metadata: null
 
 For example:
 + This is a namespaced CRD, of NvSecurityRule
-+ Nginx-pod.demo can talk to node-pod.demo over HTTP, and allowed processes are listed
-+ Node-pod.demo can talk to redis-pod.demo using the Redis protocol
++ nginx-pod.demo can talk to node-pod.demo over HTTP, and allowed processes are listed
++ node-pod.demo can talk to redis-pod.demo using the Redis protocol
 + The policymode of the services are set to Monitor mode
-+ Node-pod.demo is allowed to egress to google.com using SSL
++ node-pod.demo is allowed to egress to google.com using SSL
 + Group names such as nv.node-pod.demo are referenced but not defined in the CRD, so are expected to already exist when deployed. See below for defining Groups.
 
 
@@ -272,7 +272,7 @@ Policy mode configuration and Group definition is supported within the CRD confi
 
 Important! The imported target policy mode is not allowed to be modified from the NeuVector console (Policy -> Groups). For example, once the mode is set to Monitor, it can only be changed through CRD modification, not through the console.
 
-Note: The CRD import behavior has been changed in 4.x to ignore the PolicyMode of any 'linked' group, leaving the Policy mode unchanged if the linked group already exists. If the linked group does not exist it will be automatically created and set to the default New Services Mode in Settings -> Configuration.
+Note: The CRD import behavior ignores the PolicyMode of any 'linked' group, leaving the Policy mode unchanged if the linked group already exists. If the linked group does not exist it will be automatically created and set to the default New Services Mode in Settings -> Configuration.
 
 ####Policy Mode Configuration Requirements
 + Mode only applies to the configured Target group
@@ -322,7 +322,7 @@ Policy Mode Configuration Yaml file Example
 <strong>Criteria</strong>
 + Must not be empty unless the name is nodes, external, or containers
 + name - If the name has the service format nv.xxx.yyy, then refer to the above section Policy Mode Configuration section details
-+ key-The key conforms to the regular expression pattern ^[a-zA-Z0-9]+[.:a-zA-Z0-9_-]*$
++ key - The key conforms to the regular expression pattern ^[a-zA-Z0-9]+[.:a-zA-Z0-9_-]*$
 + op (operation)
     - string = "=" 
     - string = "!="
@@ -330,63 +330,63 @@ Policy Mode Configuration Yaml file Example
     - string = "prefix"
     - string = "regex"
     - string = "!regex"
-+ value-A string without limitations
-+ key-Must not be empty
-+ op-Operator
++ value - A string without limitations
++ key - Must not be empty
++ op - Operator
     - If the operator is equal (=) or not-equal (!=), then its’ value must not be empty.
     - If the operator is equal (=) or not-equal (!=) with a value (such as * or ?), then the value cannot have any regular expresssion format like ^$.
     - Example:
     - Key: service
     - Op :  =
     - Value: ab?c*e^$  (this is incorrect)
-+ Action-allow or deny
++ Action - Allow or deny
 + Applications (supported values)
-    -HTTP
-    -SSL
-    -SSH
-    -DNS
-    -DHCP
-    -NTP
-    -TFTP
-    -Echo
-    -RTSP
-    -SIP
-    -MySQL
-    -Redis
-    -ZooKeeper
-    -Cassandra
-    -MongoDB
-    -PostgreSQL
-    -Kafka
-    -Couchbase
-    -Wordpress
-    -ActiveMQ
-    -CouchDB"
-    -ElasticSearch
-    -Memcached
-    -RabbitMQ
-    -Radius
-    -VoltDB
-    -Consul
-    -Syslog
-    -etcd
-    -Spark
-    -Apache
-    -nginx
-    -Jetty
-    -Oracle
-    -MSSQL
-    -GRPC
-+ Port-The specified format is xxx/yyy. Where xxx=protocol(tcp, udp), and yyy=port_number (0-65535).
+    - ActiveMQ
+    - Apache
+    - Cassandra
+    - Consul
+    - Couchbase
+    - CouchDB"
+    - DHCP
+    - DNS
+    - Echo
+    - ElasticSearch
+    - etcd
+    - GRPC
+    - HTTP
+    - Jetty
+    - Kafka
+    - Memcached
+    - MongoDB
+    - MSSQL
+    - MySQL
+    - nginx
+    - NTP
+    - Oracle
+    - PostgreSQL
+    - RabbitMQ
+    - Radius
+    - Redis
+    - RTSP
+    - SIP
+    - Spark
+    - SSH
+    - SSL
+    - Syslog
+    - TFTP
+    - VoltDB
+    - Wordpress
+    - ZooKeeper
++ Port - The specified format is xxx/yyy. Where xxx=protocol(tcp, udp), and yyy=port_number (0-65535).
     - TCP/123 or TCP/any
     - UDP/123 or UDP/123
     - ICMP
     - 123 = TCP/123
-+ Process - a list of process with action, name, path for each
++ Process - A list of process with action, name, path for each
     - action: allow/deny  #This action has precedence over the file access rule.  This should be set to allow if the intent is to allow the file access rule to take effect.
     - name: process name
     - path: process path (optional)
-+ File - a list of file access rules; these apply only to the defined target container group
++ File - A list of file access rules; these apply only to the defined target container group
     - app: list of apps
     - behavior: block_access / monitor_change  #This blocks access to the defined filter below.  If monitor_change is chosen, then a security-event will be generated from the NeuVector’s webconsole Notifications > Security events page.
     - filter:  path/filename
@@ -394,7 +394,7 @@ Policy Mode Configuration Yaml file Example
 
 
 ###RBAC Support with CRDs
-Utilizing Kubernetes existing RBAC model, NeuVector extends the CRD (Custom Resource Definition) to support RBAC by utilizing Kubernetes’s Rolebinding in association with the configured Namespace in the NeuVector  configured CRD rules when using the NvSecurityRule resource-type.  This configured Namespace is then used to enforce the configured Target, which must be reside in this namespace configured in the NeuVector security policy.  When rolebinding a defined clusterrole, this can be used to bind to a Kubernetes User or Group.  The two clusterrole resources types that NeuVector supports are NvSecurityRule and NvClusterSecurityRule.
+Utilizing Kubernetes existing RBAC model, NeuVector extends the CRD (Custom Resource Definition) to support RBAC by utilizing Kubernetes’s Rolebinding in association with the configured Namespace in the NeuVector  configured CRD rules when using the NvSecurityRule resource-type. This configured Namespace is then used to enforce the configured Target, which must reside in this namespace configured in the NeuVector security policy. When rolebinding a defined clusterrole, this can be used to bind to a Kubernetes User or Group. The two clusterrole resources types that NeuVector supports are NvSecurityRule and NvClusterSecurityRule.
 
 <strong>Rolebinding & Clusterolebinding with 2 Users in different Namespaces to a Clusterrole 
 (NvSecurityRules & NvClusterSecurityRules resources)</strong>
@@ -669,7 +669,7 @@ NeuVector supports the exporting of certain NeuVector group types from a Kuberne
   spec:
 ```
 
-Note: The CRD import behavior has been changed in 4.x to ignore the PolicyMode of any 'linked' group, leaving the Policy mode unchanged if the linked group already exists. If the linked group does not exist it will be automatically created and set to the default New Services Mode in Settings -> Configuration.
+Note: The CRD import behavior ignores the PolicyMode of any 'linked' group, leaving the Policy mode unchanged if the linked group already exists. If the linked group does not exist it will be automatically created and set to the default New Services Mode in Settings -> Configuration.
 
 
 <strong>Unsupported Export Group-Types</strong>
@@ -679,7 +679,7 @@ Note: The CRD import behavior has been changed in 4.x to ignore the PolicyMode o
 <strong>Import Scenarios</strong>
 + The import will create new groups in the destination system if the groups do not yet exist in the destination environment, and the currently used Kubernetes user-context has the necessary permissions to access the namespaces configured in the CRD-yaml file to be imported.
 + If the imported group exists in the destination system with different criteria or values, the import will be rejected.
-+ The imported group exists in the destination system with identical configurations, we will reuse the existing group with different type.
++ If the imported group exists in the destination system with identical configurations, we will reuse the existing group with different type.
 
 ###CRD Samples for Global Rules
 

--- a/user/pages/06.scanning/01.scanning/02.compliance/docs.md
+++ b/user/pages/06.scanning/01.scanning/02.compliance/docs.md
@@ -68,10 +68,10 @@ The following is an example of how secrets detected in an image scan will be dis
 Here is a list of the types of secrets being detected.
 + General Private Keys
 + General detection of credentials including 'apikey', 'api_key', 'password', 'secret', 'passwd' etc.
-+ General passwords in yaml files including 'password', passwd', 'api_token' etc.
++ General passwords in yaml files including 'password', 'passwd', 'api_token' etc.
 + General secrets keys in key/value pairs
 + Putty Private key
-+ Xml Private key
++ XML Private key
 + AWS [credentials / IAM](https://docs.aws.amazon.com/general/latest/gr/aws-sec-cred-types.html)
 + Facebook client secret
 + Facebook endpoint secret

--- a/user/pages/06.scanning/01.scanning/docs.md
+++ b/user/pages/06.scanning/01.scanning/docs.md
@@ -10,13 +10,13 @@ NeuVector enables full lifecycle scanning & compliance through vulnerability sca
 Scanning is performed at all phases of the pipeline from Build to Registry to Run-Time, on various assets, as shown below.
 
 
-| **Scan Type**        | Image   | Node  | Container | Orchestrator | Function |
-| -------------------- | ------  | ----- | --------- | ------------ | -------- |
-| **Vulnerabilities**  |   Yes   |  Yes  |    Yes    |     Yes      |   Yes    |
-| **CIS Benchmarks**   |   Yes   |  Yes  |    Yes    |     Yes      |   N/A    |
-| **Custom Compliance**|   No    |  Yes  |    Yes    |     No       |   No     |
-| **Secrets**          |   Yes   |  Yes  |    Yes    |     No       |   Yes    |
-| **Modules**          |   Yes   |  N/A  |    N/A    |     N/A      |   N/A    |
+| **Scan Type**        | Image   | Node  | Container | Orchestrator |
+| -------------------- | ------  | ----- | --------- | ------------ |
+| **Vulnerabilities**  |   Yes   |  Yes  |    Yes    |     Yes      |
+| **CIS Benchmarks**   |   Yes   |  Yes  |    Yes    |     Yes      |
+| **Custom Compliance**|   No    |  Yes  |    Yes    |     No       |
+| **Secrets**          |   Yes   |  Yes  |    Yes    |     No       |
+| **Modules**          |   Yes   |  N/A  |    N/A    |     N/A      |
 
 Images are scanned either in Registry scanning or through Build-phase plug-ins such as Jenkins, CircleCI, Gitlab etc.
 
@@ -29,8 +29,6 @@ The CIS Benchmarks support by NeuVector include:
 The open source implementation of these benchmarks can be found on the [NeuVector Github page](https://github.com/neuvector).
 
 Note 1: Secrets can also be detected on Nodes and in Containers with [Custom Scripts](/policy/customcompliance).
-
-Note 2: Function scanning is provided in [Serverless Security](/serverless). [NOTE: Is this valid for v5 or should it be removed? How about the table above containing 'Function' column?]
 
 #### Kubernetes Resource Deployment File Scanning
 NeuVector is able to scan deployment yaml files for configuration assessments against Admission Control rules. This is useful to scan deployment yaml files early in the pipeline to determine if the deployment would violate any rules before attempting the deployment. Please see [Configuration Assessment](/policy/admission/assessment) under Admission Controls for more details.

--- a/user/pages/06.scanning/01.scanning/docs.md
+++ b/user/pages/06.scanning/01.scanning/docs.md
@@ -30,7 +30,7 @@ The open source implementation of these benchmarks can be found on the [NeuVecto
 
 Note 1: Secrets can also be detected on Nodes and in Containers with [Custom Scripts](/policy/customcompliance).
 
-Note 2: Function scanning is provided in [Serverless Security](/serverless).
+Note 2: Function scanning is provided in [Serverless Security](/serverless). [NOTE: Is this valid for v5 or should it be removed? How about the table above containing 'Function' column?]
 
 #### Kubernetes Resource Deployment File Scanning
 NeuVector is able to scan deployment yaml files for configuration assessments against Admission Control rules. This is useful to scan deployment yaml files early in the pipeline to determine if the deployment would violate any rules before attempting the deployment. Please see [Configuration Assessment](/policy/admission/assessment) under Admission Controls for more details.


### PR DESCRIPTION
How about unifying the first letter capitalization for the attack names, e.g. SYN flood attack -> SYN Flood attack. 
Currently some are capitalized, some not. 