### PR TITLE
Overall corrections post-migration

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -20,7 +20,7 @@ const config = {
   // For GitHub pages deployment, it is often '/<projectName>/'
 
   // ***** EDIT BEFORE MERGE *****
-  baseUrl: '/neuvector-docs/',
+  baseUrl: '/',
 
   // GitHub pages deployment config.
   // If you aren't using GitHub pages, you don't need these.
@@ -178,7 +178,7 @@ const config = {
       },
       footer: {
         style: 'dark',
-        copyright: `Copyright © ${new Date().getFullYear()} SUSE Rancher. All Rights Reserved.`,
+        copyright: `Copyright © ${new Date().getFullYear()} SUSE NeuVector. All Rights Reserved.`,
       },
       prism: {
         theme: lightCodeTheme,

--- a/src/css/index.css
+++ b/src/css/index.css
@@ -114,7 +114,7 @@ body {
 	font-size: 16px !important;
 	font-weight: normal !important;
 	text-align: center !important;
-	color: black !important;
+	/* color: black !important; */
 	background-color: none !important;
 	margin-top: -30px !important;
 	line-height: 1.2 !important;

--- a/versioned_docs/version-5.2/13.special/04.docker/04.docker.md
+++ b/versioned_docs/version-5.2/13.special/04.docker/04.docker.md
@@ -5,19 +5,13 @@ taxonomy:
 slug: /special/docker
 ---
 
-<<<<<<<< HEAD:versioned_docs/version-5.2/13.special/04.docker/04.docker.md
 ### Mirantis Kubernetes Engine
 
-Deploy to Kubernetes using the [Kubernetes Allinone](kubernetes) section. 
+Deploy to Kubernetes using the `Kubernetes Allinone` container. 
 
 ### Deploy to Swarm Cluster
 
 It’s simple to deploy NeuVector using a Swarm cluster. First, pull the NeuVector images using Docker UCP in the Images menu. You may need to add a version number to get the latest version on Docker Hub.
-========
-
-### Deploy to Swarm Cluster
-To deploy NeuVector using a Swarm cluster, first pull the NeuVector images using Docker UCP in the Images menu. You may need to add a version number to get the latest version on Docker Hub.
->>>>>>>> upstream/main:user/pages/13.special/02.docker/docs.md
 
 Currently, Swarm/UCP does not support the seccomp capabilities (cap_add options) or deploying in ‘privileged mode’ so the NeuVector containers will need to be deployed from the command line using docker-compose or run. See the sample compose files for the allinone and enforcer below.
 

--- a/versioned_docs/version-5.3/01.basics/01.basics.md
+++ b/versioned_docs/version-5.3/01.basics/01.basics.md
@@ -13,9 +13,9 @@ slug: /
 
 The images are on the NeuVector Docker Hub registry. Use the appropriate version tag for the manager, controller, enforcer, and leave the version as 'latest' for scanner and updater. For example:
 
-+ neuvector/manager:5.3.0
-+ neuvector/controller:5.3.0
-+ neuvector/enforcer:5.3.0
++ neuvector/manager:5.3.2
++ neuvector/controller:5.3.2
++ neuvector/enforcer:5.3.2
 + neuvector/scanner:latest
 + neuvector/updater:latest
 

--- a/versioned_docs/version-5.3/02.deploying/01.production/01.configmap/01.configmap.md
+++ b/versioned_docs/version-5.3/02.deploying/01.production/01.configmap/01.configmap.md
@@ -13,7 +13,7 @@ The 'always_reload: true' setting can be added in any ConfigMap yaml to force re
 
 #### Complete Sample NeuVector ConfigMap (initcfg.yaml)
 
-The latest ConfigMap can be found [here](https://raw.githubusercontent.com/neuvector/manifests/main/kubernetes/5.3.0/initcfg.yaml).
+The latest ConfigMap can be found [here](https://raw.githubusercontent.com/neuvector/manifests/main/kubernetes/5.3.2/initcfg.yaml).
 
 The sample is also shown below. This contains all the settings available. Please remove the sections not needed and edit the sections needed. Note: If using configmap in a secret, see section below for formatting changes.
 

--- a/versioned_docs/version-5.3/02.deploying/01.production/01.production.md
+++ b/versioned_docs/version-5.3/02.deploying/01.production/01.production.md
@@ -17,9 +17,9 @@ If you haven’t done so, pull the images from the NeuVector Docker Hub.
 
 The images are on the NeuVector Docker Hub registry. Use the appropriate version tag for the manager, controller, enforcer, and leave the version as 'latest' for scanner and updater. For example:
 
-+ neuvector/manager:5.3.0
-+ neuvector/controller:5.3.0
-+ neuvector/enforcer:5.3.0
++ neuvector/manager:5.3.2
++ neuvector/controller:5.3.2
++ neuvector/enforcer:5.3.2
 + neuvector/scanner:latest
 + neuvector/updater:latest
 

--- a/versioned_docs/version-5.3/02.deploying/01.production/02.operators/02.operators.md
+++ b/versioned_docs/version-5.3/02.deploying/01.production/02.operators/02.operators.md
@@ -24,7 +24,7 @@ oc delete rolebinding -n neuvector system:openshift:scc:privileged
 ```
 
 :::warning important
-NeuVector Certified Operator versions are tied to NeuVector product versions, and each new version must go through a certification process with Red Hat before being published. Certified operator version for 5.3.x is tied to helm version 2.7.2 and NeuVector app version 5.3.0. Certified operator version 1.3.9 is tied to NeuVector version 5.2.0. Certified operator version 1.3.7 is tied to NeuVector version 5.1.0. Version 1.3.4 operator version is tied to NeuVector 5.0.0. If you wish to be able to change the version tags of the NeuVector containers deployed, please use the Community version.
+NeuVector Certified Operator versions are tied to NeuVector product versions, and each new version must go through a certification process with Red Hat before being published. Certified operator version for 5.3.x is tied to helm version 2.7.2 and NeuVector app version 5.3.2. Certified operator version 1.3.9 is tied to NeuVector version 5.2.0. Certified operator version 1.3.7 is tied to NeuVector version 5.1.0. Version 1.3.4 operator version is tied to NeuVector 5.0.0. If you wish to be able to change the version tags of the NeuVector containers deployed, please use the Community version.
 :::
 
 <details>

--- a/versioned_docs/version-5.3/02.deploying/04.openshift/04.openshift.md
+++ b/versioned_docs/version-5.3/02.deploying/04.openshift/04.openshift.md
@@ -16,9 +16,9 @@ To deploy manually, first pull the appropriate NeuVector containers from the Neu
 #### NeuVector Images on Docker Hub
 
 <p>The images are on the NeuVector Docker Hub registry. Use the appropriate version tag for the manager, controller, enforcer, and leave the version as 'latest' for scanner and updater. For example:
-<li>neuvector/manager:5.3.0</li>
-<li>neuvector/controller:5.3.0</li>
-<li>neuvector/enforcer:5.3.0</li>
+<li>neuvector/manager:5.3.2</li>
+<li>neuvector/controller:5.3.2</li>
+<li>neuvector/enforcer:5.3.2</li>
 <li>neuvector/scanner:latest</li>
 <li>neuvector/updater:latest</li></p>
 <p>Please be sure to update the image references in appropriate yaml files.</p>
@@ -192,12 +192,12 @@ System:openshift:scc:neuvector-scc-controller   ClusterRole/system:openshift:scc
 6) Create the custom resources (CRD) for NeuVector security rules. For OpenShift 4.6+ (Kubernetes 1.19+):
 
 ```shell
-oc apply -f https://raw.githubusercontent.com/neuvector/manifests/main/kubernetes/5.3.0/crd-k8s-1.19.yaml
-oc apply -f https://raw.githubusercontent.com/neuvector/manifests/main/kubernetes/5.3.0/waf-crd-k8s-1.19.yaml
-oc apply -f https://raw.githubusercontent.com/neuvector/manifests/main/kubernetes/5.3.0/dlp-crd-k8s-1.19.yaml
-oc apply -f https://raw.githubusercontent.com/neuvector/manifests/main/kubernetes/5.3.0/com-crd-k8s-1.19.yaml
-oc apply -f https://raw.githubusercontent.com/neuvector/manifests/main/kubernetes/5.3.0/vul-crd-k8s-1.19.yaml
-oc apply -f https://raw.githubusercontent.com/neuvector/manifests/main/kubernetes/5.3.0/admission-crd-k8s-1.19.yaml
+oc apply -f https://raw.githubusercontent.com/neuvector/manifests/main/kubernetes/5.3.2/crd-k8s-1.19.yaml
+oc apply -f https://raw.githubusercontent.com/neuvector/manifests/main/kubernetes/5.3.2/waf-crd-k8s-1.19.yaml
+oc apply -f https://raw.githubusercontent.com/neuvector/manifests/main/kubernetes/5.3.2/dlp-crd-k8s-1.19.yaml
+oc apply -f https://raw.githubusercontent.com/neuvector/manifests/main/kubernetes/5.3.2/com-crd-k8s-1.19.yaml
+oc apply -f https://raw.githubusercontent.com/neuvector/manifests/main/kubernetes/5.3.2/vul-crd-k8s-1.19.yaml
+oc apply -f https://raw.githubusercontent.com/neuvector/manifests/main/kubernetes/5.3.2/admission-crd-k8s-1.19.yaml
 ```
 
 7) Add read permission to access the kubernetes API and OpenShift RBACs. IMPORTANT: The standard NeuVector 5.2+ deployment uses least-privileged service accounts instead of the default. See below if upgrading to 5.2+ from a version prior to 5.2.
@@ -351,7 +351,7 @@ The name of your default OpenShift registry might have changed from docker-regis
 Type NodePort is used for the fed-master and fed-worker services instead of LoadBalancer. You may need to adjust for your deployment.
 :::
 
-If using the CRI-O run-time, see this [CRI-O sample](https://raw.githubusercontent.com/neuvector/manifests/main/kubernetes/5.3.0/neuvector-crio-oc.yaml).
+If using the CRI-O run-time, see this [CRI-O sample](https://raw.githubusercontent.com/neuvector/manifests/main/kubernetes/5.3.2/neuvector-crio-oc.yaml).
 
 **Master Node Taints and Tolerations**
 

--- a/versioned_docs/version-5.3/02.deploying/09.airgap/09.airgap.md
+++ b/versioned_docs/version-5.3/02.deploying/09.airgap/09.airgap.md
@@ -62,10 +62,10 @@ drwxr-xr-x. 2 root root   153 Jan  8 14:35 images
 
 neuvector/images:
 total 953920
--rw-r--r--. 1 root root 236693504 Jan  8 14:35 controller_5.3.0.tar
--rw-r--r--. 1 root root 226704384 Jan  8 14:35 enforcer_5.3.0.tar
+-rw-r--r--. 1 root root 236693504 Jan  8 14:35 controller_5.3.2.tar
+-rw-r--r--. 1 root root 226704384 Jan  8 14:35 enforcer_5.3.2.tar
 -rw-r--r--. 1 root root       176 Jan  8 14:34 list.txt
--rw-r--r--. 1 root root 331550208 Jan  8 14:35 manager_5.3.0.tar
+-rw-r--r--. 1 root root 331550208 Jan  8 14:35 manager_5.3.2.tar
 -rw-r--r--. 1 root root 169589760 Jan  8 14:35 scanner_latest.tar
 -rw-r--r--. 1 root root  12265472 Jan  8 14:35 updater_latest.tar
 ```
@@ -114,5 +114,5 @@ export REGISTRY=registry.awesome.sauce  # registry URL
 export NEU_URL=neuvector.awesome.sauce   # neuvector URL
 
 # helm all the things -- read all the options being set
-helm upgrade -i neuvector --namespace neuvector neuvector/core --create-namespace  --set imagePullSecrets=regsecret --set k3s.enabled=true --set k3s.runtimePath=/run/k3s/containerd/containerd.sock  --set manager.ingress.enabled=true --set controller.pvc.enabled=true --set controller.pvc.capacity=10Gi --set manager.svc.type=ClusterIP --set registry=$REGISTRY --set tag=5.3.0 --set controller.image.repository=neuvector/controller --set enforcer.image.repository=neuvector/enforcer --set manager.image.repository=neuvector/manager --set cve.updater.image.repository=neuvector/updater --set manager.ingress.host=$NEU_URL
+helm upgrade -i neuvector --namespace neuvector neuvector/core --create-namespace  --set imagePullSecrets=regsecret --set k3s.enabled=true --set k3s.runtimePath=/run/k3s/containerd/containerd.sock  --set manager.ingress.enabled=true --set controller.pvc.enabled=true --set controller.pvc.capacity=10Gi --set manager.svc.type=ClusterIP --set registry=$REGISTRY --set tag=5.3.2 --set controller.image.repository=neuvector/controller --set enforcer.image.repository=neuvector/enforcer --set manager.image.repository=neuvector/manager --set cve.updater.image.repository=neuvector/updater --set manager.ingress.host=$NEU_URL
 ```

--- a/versioned_docs/version-5.3/03.configuration/03.customui/03.customui.md
+++ b/versioned_docs/version-5.3/03.configuration/03.customui/03.customui.md
@@ -184,7 +184,7 @@ Follow these steps to customize the UI component:
         serviceAccount: basic
         containers:
           - name: neuvector-manager-pod
-            image: neuvector/manager:5.3.0
+            image: neuvector/manager:5.3.2
             env:
               - name: CUSTOM_PAGE_HEADER_COLOR
                 value: "#ff8c00"

--- a/versioned_docs/version-5.3/06.scanning/02.registry/01.harbor/01.harbor.md
+++ b/versioned_docs/version-5.3/06.scanning/02.registry/01.harbor/01.harbor.md
@@ -39,4 +39,4 @@ Scan results can be viewed directly in Harbor.
 
 #### Sample Deployment Yaml
 
-Samples for [Kubernetes](https://raw.githubusercontent.com/neuvector/manifests/main/kubernetes/5.3.0/neuvector-registry-adapter-k8s.yaml) and [OpenShift](https://raw.githubusercontent.com/neuvector/manifests/main/kubernetes/5.3.0/neuvector-registry-adapter-oc.yaml)
+Samples for [Kubernetes](https://raw.githubusercontent.com/neuvector/manifests/main/kubernetes/5.3.2/neuvector-registry-adapter-k8s.yaml) and [OpenShift](https://raw.githubusercontent.com/neuvector/manifests/main/kubernetes/5.3.2/neuvector-registry-adapter-oc.yaml)


### PR DESCRIPTION
The following corrections have been applied to fix issues due to the Docusaurus migration:

- Configuration: set `routeBasePath` to `/`
- Configuration: change footer copyright to `SUSE NeuVector`
- Remove broken link in 5.2 version
- Update neuvector images version to `5.3.2` in 5.3 version
- CSS updated to be adapted for Docusaurus light and dark themes

Signed-off-by: Nuno do Carmo <nuno.carmo@suse.com>