### PR TITLE
Applied #74 changes to v5.3 (current)

### DIFF
--- a/versioned_docs/version-5.3/04.navigation/01.navigation/01.navigation.md
+++ b/versioned_docs/version-5.3/04.navigation/01.navigation/01.navigation.md
@@ -149,7 +149,7 @@ The [Automated Promotion of Group Modes](/policy/modes#automated-promotion-of-gr
 
 The Auto-Deletion of Unused Groups is useful for automated 'clean-up' of the discovered (and auto-created rules for) groups which are no longer in use, especially high-churn development environments. See Policy -> Groups for the list of groups in NeuVector. Removing unused Groups will clean up the Groups list and all associated rules for those groups.
 
-The XFF-FORWARDED-FOR enables/disables use of these headers in enforcing NeuVector network rules. This is useful to retain the original source IP of an ingress connection so it can be used for network rules enforcement. Enable means the source IP will be retained. See below for a detailed explanation. 
+The X-FORWARDED-FOR enables/disables use of these headers in enforcing NeuVector network rules. This is useful to retain the original source IP of an ingress connection so it can be used for network rules enforcement. Enable means the source IP will be retained. See below for a detailed explanation. 
 
 Multiple webhooks can be configured to be used in [Response Rules](/policy/responserules) for customized notifications. Webhook format choices include Slack, JSON, and key-value pairs.
 
@@ -163,7 +163,7 @@ Import/Export the Security Policy file. You can configure SSO for SAML and LDAP/
 
 The Usage Report and Collect Log exports may be requested by your NeuVector support team.
 
-###### XFF-FORWARDED-FOR Behavior Details
+###### X-FORWARDED-FOR Behavior Details
 
 In a Kubernetes cluster, an application can be exposed to the outside of the cluster by a NodePort, LoadBalancer or Ingress services. These services typically replace the source IP while doing the Source NAT (SNAT) on the packets. As the original source IP is masqueraded, this prevents NeuVector from recognizing the connection is actually from the 'external'.
 

--- a/versioned_docs/version-5.3/05.policy/05.networkrules/05.networkrules.md
+++ b/versioned_docs/version-5.3/05.policy/05.networkrules/05.networkrules.md
@@ -68,7 +68,7 @@ Be sure to click Deploy to save the new rule.
 
 Finally, review the list of rules to make sure the new rule is in the order and priority desired. Rules are applied from top to bottom.
 
-#### Ingress IP Policy Based on XFF-FORWARDED-FOR 
+#### Ingress IP Policy Based on X-FORWARDED-FOR 
 
 In a Kubernetes cluster, an application can be exposed to the outside of the cluster by a NodePort, LoadBalancer or Ingress services. These services typically replace the source IP while doing the Source NAT (SNAT) on the packets. As the original source IP is masqueraded, this prevents NeuVector from recognizing the connection is actually from the 'external'.
 


### PR DESCRIPTION
The PR #74 targeted only `next`. The changes have been applied to the current version, 5.3.

Signed-off-by: Nuno do Carmo <nuno.carmo@suse.com>