### PR TITLE
Added CNAME file

### DIFF
--- a/static/CNAME
+++ b/static/CNAME
@@ -1,0 +1,1 @@
+open-docs.neuvector.com


### PR DESCRIPTION
The CNAME file is required by Github Pages for the configuration of the DNS alias: open-docs.neuvector.com.

Signed-off-by: Nuno do Carmo <nuno.carmo@suse.com>