### PR TITLE
Applied commit efd8dfd

### DIFF
--- a/docs/14.releasenotes/01.5x/01.5x.md
+++ b/docs/14.releasenotes/01.5x/01.5x.md
@@ -11,7 +11,17 @@ slug: /releasenotes/5x
 To receive email notifications of new releases, please subscribe to this SUSE mailing list: https://lists.suse.com/mailman/listinfo/neuvector-updates
 :::
 
+#### 5.3.2 April 2024
+
+##### Bug Fixes
+
++ After upgrading to v5.3.1 from a previous NeuVector release, pre-existing NvClusterSecurityRule custom resources may be deleted inadvertently. NOTE: The 5.3.1 version has been removed from docker hub in order to prevent the upgrade issue.
+
 #### 5.3.1 April 2024
+
+:::danger important
+The 5.3.1 version has been removed from docker hub in order to prevent the upgrade issue fixed in 5.3.2. Please use the 5.3.2 release.
+:::
 
 ##### Enhancements
 + Allow users to define ‘accepted’ vulnerabilities when using Github actions so they don’t affect workflows.

--- a/versioned_docs/version-5.3/14.releasenotes/01.5x/01.5x.md
+++ b/versioned_docs/version-5.3/14.releasenotes/01.5x/01.5x.md
@@ -11,7 +11,17 @@ slug: /releasenotes/5x
 To receive email notifications of new releases, please subscribe to this SUSE mailing list: https://lists.suse.com/mailman/listinfo/neuvector-updates
 :::
 
+#### 5.3.2 April 2024
+
+##### Bug Fixes
+
++ After upgrading to v5.3.1 from a previous NeuVector release, pre-existing NvClusterSecurityRule custom resources may be deleted inadvertently. NOTE: The 5.3.1 version has been removed from docker hub in order to prevent the upgrade issue.
+
 #### 5.3.1 April 2024
+
+:::danger important
+The 5.3.1 version has been removed from docker hub in order to prevent the upgrade issue fixed in 5.3.2. Please use the 5.3.2 release.
+:::
 
 ##### Enhancements
 + Allow users to define ‘accepted’ vulnerabilities when using Github actions so they don’t affect workflows.


### PR DESCRIPTION
The commit efd8dfd added the release notes for 5.3.2 and was only applied to the "old docs site".

Signed-off-by: Nuno do Carmo <nuno.carmo@suse.com>