### PR TITLE
Fixed URL versions for v5.3

### DIFF
--- a/docs/02.deploying/02.kubernetes/02.kubernetes.md
+++ b/docs/02.deploying/02.kubernetes/02.kubernetes.md
@@ -78,12 +78,12 @@ kubectl label  namespace neuvector "pod-security.kubernetes.io/enforce=privilege
 Create the custom resources (CRD) for NeuVector security rules. For Kubernetes 1.19+:
 
 ```shell
-kubectl apply -f https://raw.githubusercontent.com/neuvector/manifests/main/kubernetes/5.3.2/crd-k8s-1.19.yaml
-kubectl apply -f https://raw.githubusercontent.com/neuvector/manifests/main/kubernetes/5.3.2/waf-crd-k8s-1.19.yaml
-kubectl apply -f https://raw.githubusercontent.com/neuvector/manifests/main/kubernetes/5.3.2/dlp-crd-k8s-1.19.yaml
-kubectl apply -f https://raw.githubusercontent.com/neuvector/manifests/main/kubernetes/5.3.2/com-crd-k8s-1.19.yaml
-kubectl apply -f https://raw.githubusercontent.com/neuvector/manifests/main/kubernetes/5.3.2/vul-crd-k8s-1.19.yaml
-kubectl apply -f https://raw.githubusercontent.com/neuvector/manifests/main/kubernetes/5.3.2/admission-crd-k8s-1.19.yaml
+kubectl apply -f https://raw.githubusercontent.com/neuvector/manifests/main/kubernetes/5.3.0/crd-k8s-1.19.yaml
+kubectl apply -f https://raw.githubusercontent.com/neuvector/manifests/main/kubernetes/5.3.0/waf-crd-k8s-1.19.yaml
+kubectl apply -f https://raw.githubusercontent.com/neuvector/manifests/main/kubernetes/5.3.0/dlp-crd-k8s-1.19.yaml
+kubectl apply -f https://raw.githubusercontent.com/neuvector/manifests/main/kubernetes/5.3.0/com-crd-k8s-1.19.yaml
+kubectl apply -f https://raw.githubusercontent.com/neuvector/manifests/main/kubernetes/5.3.0/vul-crd-k8s-1.19.yaml
+kubectl apply -f https://raw.githubusercontent.com/neuvector/manifests/main/kubernetes/5.3.0/admission-crd-k8s-1.19.yaml
 ```
 </li>
 <li>
@@ -225,7 +225,7 @@ kubectl create -f nv_master_worker.yaml
 Create the primary NeuVector services and pods using the preset version commands or modify the sample yaml below. The preset version invoke a LoadBalancer for the NeuVector Console. If using the sample yaml file below replace the image names and &lt;version> tags for the manager, controller and enforcer image references in the yaml file. Also make any other modifications required for your deployment environment (such as LoadBalancer/NodePort/Ingress for manager access etc).
 
 ```shell
-kubectl apply -f https://raw.githubusercontent.com/neuvector/manifests/main/kubernetes/5.3.2/neuvector-k8s.yaml
+kubectl apply -f https://raw.githubusercontent.com/neuvector/manifests/main/kubernetes/5.3.0/neuvector-k8s.yaml
 ```
 
 Or, if modifying any of the above yaml or samples from below:

--- a/docs/10.updating/01.updating/01.updating.md
+++ b/docs/10.updating/01.updating/01.updating.md
@@ -64,7 +64,7 @@ kubectl set image DaemonSet/neuvector-enforcer-pod neuvector-enforcer-pod=neuvec
 To check the status of the rolling update:
 
 ```shell
-kubectl rollout status -n neuvector ds/neuvector-enforcer pod
+kubectl rollout status -n neuvector ds/neuvector-enforcer-pod
 kubectl rollout status -n neuvector deployment/neuvector-controller-pod  # same for manager, scanner etc
 ```
 

--- a/versioned_docs/version-5.3/02.deploying/01.production/01.configmap/01.configmap.md
+++ b/versioned_docs/version-5.3/02.deploying/01.production/01.configmap/01.configmap.md
@@ -13,7 +13,7 @@ The 'always_reload: true' setting can be added in any ConfigMap yaml to force re
 
 #### Complete Sample NeuVector ConfigMap (initcfg.yaml)
 
-The latest ConfigMap can be found [here](https://raw.githubusercontent.com/neuvector/manifests/main/kubernetes/5.3.2/initcfg.yaml).
+The latest ConfigMap can be found [here](https://raw.githubusercontent.com/neuvector/manifests/main/kubernetes/5.3.0/initcfg.yaml).
 
 The sample is also shown below. This contains all the settings available. Please remove the sections not needed and edit the sections needed. Note: If using configmap in a secret, see section below for formatting changes.
 

--- a/versioned_docs/version-5.3/02.deploying/02.kubernetes/02.kubernetes.md
+++ b/versioned_docs/version-5.3/02.deploying/02.kubernetes/02.kubernetes.md
@@ -78,12 +78,12 @@ kubectl label  namespace neuvector "pod-security.kubernetes.io/enforce=privilege
 Create the custom resources (CRD) for NeuVector security rules. For Kubernetes 1.19+:
 
 ```shell
-kubectl apply -f https://raw.githubusercontent.com/neuvector/manifests/main/kubernetes/5.3.2/crd-k8s-1.19.yaml
-kubectl apply -f https://raw.githubusercontent.com/neuvector/manifests/main/kubernetes/5.3.2/waf-crd-k8s-1.19.yaml
-kubectl apply -f https://raw.githubusercontent.com/neuvector/manifests/main/kubernetes/5.3.2/dlp-crd-k8s-1.19.yaml
-kubectl apply -f https://raw.githubusercontent.com/neuvector/manifests/main/kubernetes/5.3.2/com-crd-k8s-1.19.yaml
-kubectl apply -f https://raw.githubusercontent.com/neuvector/manifests/main/kubernetes/5.3.2/vul-crd-k8s-1.19.yaml
-kubectl apply -f https://raw.githubusercontent.com/neuvector/manifests/main/kubernetes/5.3.2/admission-crd-k8s-1.19.yaml
+kubectl apply -f https://raw.githubusercontent.com/neuvector/manifests/main/kubernetes/5.3.0/crd-k8s-1.19.yaml
+kubectl apply -f https://raw.githubusercontent.com/neuvector/manifests/main/kubernetes/5.3.0/waf-crd-k8s-1.19.yaml
+kubectl apply -f https://raw.githubusercontent.com/neuvector/manifests/main/kubernetes/5.3.0/dlp-crd-k8s-1.19.yaml
+kubectl apply -f https://raw.githubusercontent.com/neuvector/manifests/main/kubernetes/5.3.0/com-crd-k8s-1.19.yaml
+kubectl apply -f https://raw.githubusercontent.com/neuvector/manifests/main/kubernetes/5.3.0/vul-crd-k8s-1.19.yaml
+kubectl apply -f https://raw.githubusercontent.com/neuvector/manifests/main/kubernetes/5.3.0/admission-crd-k8s-1.19.yaml
 ```
 </li>
 <li>
@@ -225,7 +225,7 @@ kubectl create -f nv_master_worker.yaml
 Create the primary NeuVector services and pods using the preset version commands or modify the sample yaml below. The preset version invoke a LoadBalancer for the NeuVector Console. If using the sample yaml file below replace the image names and &lt;version> tags for the manager, controller and enforcer image references in the yaml file. Also make any other modifications required for your deployment environment (such as LoadBalancer/NodePort/Ingress for manager access etc).
 
 ```shell
-kubectl apply -f https://raw.githubusercontent.com/neuvector/manifests/main/kubernetes/5.3.2/neuvector-k8s.yaml
+kubectl apply -f https://raw.githubusercontent.com/neuvector/manifests/main/kubernetes/5.3.0/neuvector-k8s.yaml
 ```
 
 Or, if modifying any of the above yaml or samples from below:

--- a/versioned_docs/version-5.3/02.deploying/04.openshift/04.openshift.md
+++ b/versioned_docs/version-5.3/02.deploying/04.openshift/04.openshift.md
@@ -192,12 +192,12 @@ System:openshift:scc:neuvector-scc-controller   ClusterRole/system:openshift:scc
 6) Create the custom resources (CRD) for NeuVector security rules. For OpenShift 4.6+ (Kubernetes 1.19+):
 
 ```shell
-oc apply -f https://raw.githubusercontent.com/neuvector/manifests/main/kubernetes/5.3.2/crd-k8s-1.19.yaml
-oc apply -f https://raw.githubusercontent.com/neuvector/manifests/main/kubernetes/5.3.2/waf-crd-k8s-1.19.yaml
-oc apply -f https://raw.githubusercontent.com/neuvector/manifests/main/kubernetes/5.3.2/dlp-crd-k8s-1.19.yaml
-oc apply -f https://raw.githubusercontent.com/neuvector/manifests/main/kubernetes/5.3.2/com-crd-k8s-1.19.yaml
-oc apply -f https://raw.githubusercontent.com/neuvector/manifests/main/kubernetes/5.3.2/vul-crd-k8s-1.19.yaml
-oc apply -f https://raw.githubusercontent.com/neuvector/manifests/main/kubernetes/5.3.2/admission-crd-k8s-1.19.yaml
+oc apply -f https://raw.githubusercontent.com/neuvector/manifests/main/kubernetes/5.3.0/crd-k8s-1.19.yaml
+oc apply -f https://raw.githubusercontent.com/neuvector/manifests/main/kubernetes/5.3.0/waf-crd-k8s-1.19.yaml
+oc apply -f https://raw.githubusercontent.com/neuvector/manifests/main/kubernetes/5.3.0/dlp-crd-k8s-1.19.yaml
+oc apply -f https://raw.githubusercontent.com/neuvector/manifests/main/kubernetes/5.3.0/com-crd-k8s-1.19.yaml
+oc apply -f https://raw.githubusercontent.com/neuvector/manifests/main/kubernetes/5.3.0/vul-crd-k8s-1.19.yaml
+oc apply -f https://raw.githubusercontent.com/neuvector/manifests/main/kubernetes/5.3.0/admission-crd-k8s-1.19.yaml
 ```
 
 7) Add read permission to access the kubernetes API and OpenShift RBACs. IMPORTANT: The standard NeuVector 5.2+ deployment uses least-privileged service accounts instead of the default. See below if upgrading to 5.2+ from a version prior to 5.2.
@@ -351,7 +351,7 @@ The name of your default OpenShift registry might have changed from docker-regis
 Type NodePort is used for the fed-master and fed-worker services instead of LoadBalancer. You may need to adjust for your deployment.
 :::
 
-If using the CRI-O run-time, see this [CRI-O sample](https://raw.githubusercontent.com/neuvector/manifests/main/kubernetes/5.3.2/neuvector-crio-oc.yaml).
+If using the CRI-O run-time, see this [CRI-O sample](https://raw.githubusercontent.com/neuvector/manifests/main/kubernetes/5.3.0/neuvector-crio-oc.yaml).
 
 **Master Node Taints and Tolerations**
 

--- a/versioned_docs/version-5.3/06.scanning/02.registry/01.harbor/01.harbor.md
+++ b/versioned_docs/version-5.3/06.scanning/02.registry/01.harbor/01.harbor.md
@@ -39,4 +39,4 @@ Scan results can be viewed directly in Harbor.
 
 #### Sample Deployment Yaml
 
-Samples for [Kubernetes](https://raw.githubusercontent.com/neuvector/manifests/main/kubernetes/5.3.2/neuvector-registry-adapter-k8s.yaml) and [OpenShift](https://raw.githubusercontent.com/neuvector/manifests/main/kubernetes/5.3.2/neuvector-registry-adapter-oc.yaml)
+Samples for [Kubernetes](https://raw.githubusercontent.com/neuvector/manifests/main/kubernetes/5.3.0/neuvector-registry-adapter-k8s.yaml) and [OpenShift](https://raw.githubusercontent.com/neuvector/manifests/main/kubernetes/5.3.0/neuvector-registry-adapter-oc.yaml)

--- a/versioned_docs/version-5.3/10.updating/01.updating/01.updating.md
+++ b/versioned_docs/version-5.3/10.updating/01.updating/01.updating.md
@@ -64,7 +64,7 @@ kubectl set image DaemonSet/neuvector-enforcer-pod neuvector-enforcer-pod=neuvec
 To check the status of the rolling update:
 
 ```shell
-kubectl rollout status -n neuvector ds/neuvector-enforcer pod
+kubectl rollout status -n neuvector ds/neuvector-enforcer-pod
 kubectl rollout status -n neuvector deployment/neuvector-controller-pod  # same for manager, scanner etc
 ```
 


### PR DESCRIPTION
The manifests images versions had a wrong "patch level" number. It has been changed from `5.3.2` to `5.3.0`.

A small typo in `updating/updating` has also been fixed.

Signed-off-by: Nuno do Carmo <nuno.carmo@suse.com>