### PR TITLE
Update 01.console.md

### DIFF
--- a/versioned_docs/version-5.3/03.configuration/01.console/01.console.md
+++ b/versioned_docs/version-5.3/03.configuration/01.console/01.console.md
@@ -7,10 +7,19 @@ slug: /configuration/console
 
 ### Connect to UI
 
-Open a browser window, connect to the manager or all-in-one container's host IP on default port 8443 using HTTPS. After accepting the EULA, the user is able to access the UI.
+Open a browser window, connect to the manager using HTTPS. After accepting the EULA, the user is able to access the UI.
 
+#### Docker
 ```shell
 https://<manager_host_ip>:8443
+```
+#### Kubernetes without LoadBalancer or Ingress configured
+```shell
+https://<node_host_ip>:<NodePort>
+```
+#### LB/Ingress/Route
+```shell
+https://<FQDN|IP>/
 ```
 
 ![Navigation](3_0_Dashboard.png)


### PR DESCRIPTION
Updated the various URLs the manager should be accessed.  The k8s default for manager svc is NodePort.