### PR TITLE
Removed duplicate titles

### DIFF
--- a/versioned_docs/version-5.2/01.basics/01.basics.md
+++ b/versioned_docs/version-5.2/01.basics/01.basics.md
@@ -1,5 +1,5 @@
 ---
-title: NeuVector Docs
+title: ""
 sidebar_label: 1. Basics
 taxonomy:
     category: docs

--- a/versioned_docs/version-5.3/01.basics/01.basics.md
+++ b/versioned_docs/version-5.3/01.basics/01.basics.md
@@ -1,5 +1,5 @@
 ---
-title: NeuVector Docs
+title: ""
 sidebar_label: 1. Basics
 taxonomy:
     category: docs


### PR DESCRIPTION
The versions 5.2 and 5.3 had a duplicate title in the welcome page. The duplicate title has been removed.

Signed-off-by: Nuno do Carmo <nuno.carmo@suse.com>
