### PR TITLE
fix: Link to Red Hat Certified Operator updated, previous one was broken.

### DIFF
--- a/docs/02.deploying/01.production/02.operators/02.operators.md
+++ b/docs/02.deploying/01.production/02.operators/02.operators.md
@@ -13,7 +13,7 @@ Operators take human operational knowledge and encode it into software that is m
 
 The NeuVector Operator is based on the NeuVector Helm chart. The NeuVector RedHat OpenShift Operator runs in the OpenShift container platform to deploy and manage the NeuVector Security cluster components. The NeuVector Operator contains all necessary information to deploy NeuVector using Helm charts. You simply need to install the NeuVector operator from the OpenShift embedded Operator hub and create the NeuVector instance.
 
-To deploy the latest NeuVector container versions, please use either the [Red Hat Certified Operator](https://catalog.redhat.com/software/operators/search?q=neuvector) from Operator Hub or the [community operator](https://github.com/redhat-openshift-ecosystem/community-operators-prod/tree/main/operators/neuvector-community-operator). Documentation for the community operator can be found [here](https://github.com/neuvector/neuvector-operator).
+To deploy the latest NeuVector container versions, please use either the [Red Hat Certified Operator](https://catalog.redhat.com/search?searchType=software&deployed_as=Operator&partnerName=NeuVector&p=1) from Operator Hub or the [community operator](https://github.com/redhat-openshift-ecosystem/community-operators-prod/tree/main/operators/neuvector-community-operator). Documentation for the community operator can be found [here](https://github.com/neuvector/neuvector-operator).
 
 **Note about SCC and Upgrading**
 

--- a/versioned_docs/version-5.2/02.deploying/01.production/02.operators/02.operators.md
+++ b/versioned_docs/version-5.2/02.deploying/01.production/02.operators/02.operators.md
@@ -13,7 +13,7 @@ Operators take human operational knowledge and encode it into software that is m
 
 The NeuVector Operator is based on the NeuVector Helm chart. The NeuVector RedHat OpenShift Operator runs in the OpenShift container platform to deploy and manage the NeuVector Security cluster components. The NeuVector Operator contains all necessary information to deploy NeuVector using Helm charts. You simply need to install the NeuVector operator from the OpenShift embedded Operator hub and create the NeuVector instance.
 
-To deploy the latest NeuVector container versions, please use either the [Red Hat Certified Operator](https://catalog.redhat.com/software/operators/search?q=neuvector) from Operator Hub or the [community operator](https://github.com/redhat-openshift-ecosystem/community-operators-prod/tree/main/operators/neuvector-community-operator). Documentation for the community operator can be found [here](https://github.com/neuvector/neuvector-operator).
+To deploy the latest NeuVector container versions, please use either the [Red Hat Certified Operator](https://catalog.redhat.com/search?searchType=software&deployed_as=Operator&partnerName=NeuVector&p=1) from Operator Hub or the [community operator](https://github.com/redhat-openshift-ecosystem/community-operators-prod/tree/main/operators/neuvector-community-operator). Documentation for the community operator can be found [here](https://github.com/neuvector/neuvector-operator).
 
 **Note about SCC and Upgrading**
 

--- a/versioned_docs/version-5.3/02.deploying/01.production/02.operators/02.operators.md
+++ b/versioned_docs/version-5.3/02.deploying/01.production/02.operators/02.operators.md
@@ -13,7 +13,7 @@ Operators take human operational knowledge and encode it into software that is m
 
 The NeuVector Operator is based on the NeuVector Helm chart. The NeuVector RedHat OpenShift Operator runs in the OpenShift container platform to deploy and manage the NeuVector Security cluster components. The NeuVector Operator contains all necessary information to deploy NeuVector using Helm charts. You simply need to install the NeuVector operator from the OpenShift embedded Operator hub and create the NeuVector instance.
 
-To deploy the latest NeuVector container versions, please use either the [Red Hat Certified Operator](https://catalog.redhat.com/software/operators/search?q=neuvector) from Operator Hub or the [community operator](https://github.com/redhat-openshift-ecosystem/community-operators-prod/tree/main/operators/neuvector-community-operator). Documentation for the community operator can be found [here](https://github.com/neuvector/neuvector-operator).
+To deploy the latest NeuVector container versions, please use either the [Red Hat Certified Operator](https://catalog.redhat.com/search?searchType=software&deployed_as=Operator&partnerName=NeuVector&p=1) from Operator Hub or the [community operator](https://github.com/redhat-openshift-ecosystem/community-operators-prod/tree/main/operators/neuvector-community-operator). Documentation for the community operator can be found [here](https://github.com/neuvector/neuvector-operator).
 
 **Note about SCC and Upgrading**
 


### PR DESCRIPTION
Previous linked `https://catalog.redhat.com/software/operators/search?q=neuvector` redirects to `https://catalog.redhat.com/search?searchType=software&deployed_as=Operator` which gives 289 results and isn't narrowed down to `NeuVector`. 
The proposed new link `https://catalog.redhat.com/search?searchType=software&deployed_as=Operator&partnerName=NeuVector&p=1` behaves as the old one and returns two results published by NeuVector.