### PR TITLE
Corrected typo

### DIFF
--- a/docs/12.troubleshooting/01.troubleshooting/01.troubleshooting.md
+++ b/docs/12.troubleshooting/01.troubleshooting/01.troubleshooting.md
@@ -23,7 +23,7 @@ The NeuVector containers are deployed, managed, and updated using the same orche
 
 + Directory integration. NeuVector supports specific configurations for LDAP/AD and other integrations for groups and roles. Contact NeuVector for additional troubleshooting steps and a tool for AD troubleshooting.
 + Registry scanning. Most issues are related to registry authentication errors or inability for the controller to access the registry from the cluster.
-+ For performance issues, make sure the controller is allocated enough memory for scanning large images. Also, CPU and memory minimums can be specified in the pod policy to ensure adequate performance at scale.
++ For performance issues, make sure the scanner is allocated enough memory for scanning large images. Also, CPU and memory minimums can be specified in the pod policy to ensure adequate performance at scale.
 + Admission Control. See the Troubleshooting section in the section Security Risks... -> Admission Controls.
 
 #### Updating

--- a/versioned_docs/version-5.2/12.troubleshooting/01.troubleshooting/01.troubleshooting.md
+++ b/versioned_docs/version-5.2/12.troubleshooting/01.troubleshooting/01.troubleshooting.md
@@ -23,7 +23,7 @@ The NeuVector containers are deployed, managed, and updated using the same orche
 
 + Directory integration. NeuVector supports specific configurations for LDAP/AD and other integrations for groups and roles. Contact NeuVector for additional troubleshooting steps and a tool for AD troubleshooting.
 + Registry scanning. Most issues are related to registry authentication errors or inability for the controller to access the registry from the cluster.
-+ For performance issues, make sure the controller is allocated enough memory for scanning large images. Also, CPU and memory minimums can be specified in the pod policy to ensure adequate performance at scale.
++ For performance issues, make sure the scanner is allocated enough memory for scanning large images. Also, CPU and memory minimums can be specified in the pod policy to ensure adequate performance at scale.
 + Admission Control. See the Troubleshooting section in the section Security Risks... -> Admission Controls.
 
 #### Updating

--- a/versioned_docs/version-5.3/12.troubleshooting/01.troubleshooting/01.troubleshooting.md
+++ b/versioned_docs/version-5.3/12.troubleshooting/01.troubleshooting/01.troubleshooting.md
@@ -23,7 +23,7 @@ The NeuVector containers are deployed, managed, and updated using the same orche
 
 + Directory integration. NeuVector supports specific configurations for LDAP/AD and other integrations for groups and roles. Contact NeuVector for additional troubleshooting steps and a tool for AD troubleshooting.
 + Registry scanning. Most issues are related to registry authentication errors or inability for the controller to access the registry from the cluster.
-+ For performance issues, make sure the controller is allocated enough memory for scanning large images. Also, CPU and memory minimums can be specified in the pod policy to ensure adequate performance at scale.
++ For performance issues, make sure the scanner is allocated enough memory for scanning large images. Also, CPU and memory minimums can be specified in the pod policy to ensure adequate performance at scale.
 + Admission Control. See the Troubleshooting section in the section Security Risks... -> Admission Controls.
 
 #### Updating


### PR DESCRIPTION
Fixes #94

As stated in the issue, `controller` was wrongly referenced instead of `scanner`.

Signed-off-by: Nuno do Carmo nuno.carmo@suse.com