### PR TITLE
Updated replacing certificates for internal communications

### DIFF
--- a/docs/02.deploying/01.production/04.internal/04.internal.md
+++ b/docs/02.deploying/01.production/04.internal/04.internal.md
@@ -164,7 +164,61 @@ cat old-ca.crt > /tmp/ca.crt
 cat ca.crt >> /tmp/ca.crt
 ```
 
-+ Update the Kubernetes secret
++ Update the Kubernetes secret with the new `ca.crt`
+
+```bash
+kubectl delete secret internal-cert -n neuvector
+kubectl create secret generic internal-cert -n neuvector  --from-file=tls.key=old-tls.key --from-file=tls.crt=old-tls.crt --from-file=ca.crt=/tmp/ca.crt
+```
+
++ Restart the deployments in order to use the updated certificate
+
+```bash
+kubectl rollout restart deployment neuvector-controller-pod
+kubectl rollout restart deployment neuvector-scanner-pod
+kubectl rollout restart deployment neuvector-registry-adapter-pod 
+kubectl rollout restart ds neuvector-enforcer-pod
+```
+
++ Wait for the restart to complete
+
+```bash
+kubectl rollout status deployment neuvector-controller-pod
+kubectl rollout status deployment neuvector-scanner-pod
+kubectl rollout status deployment neuvector-registry-adapter-pod 
+kubectl rollout status ds neuvector-enforcer-pod
+```
+
++ Make sure the console can be accessed and controllers are all online.
+
++ Update the Kubernetes secret with the new `ca.crt`
+
+```bash
+kubectl delete secret internal-cert -n neuvector
+kubectl create secret generic internal-cert -n neuvector  --from-file=tls.key=old-tls.key --from-file=tls.crt=old-tls.crt --from-file=ca.crt=/tmp/ca.crt
+```
+
++ Restart the deployments in order to use the updated certificate
+
+```bash
+kubectl rollout restart deployment neuvector-controller-pod
+kubectl rollout restart deployment neuvector-scanner-pod
+kubectl rollout restart deployment neuvector-registry-adapter-pod 
+kubectl rollout restart ds neuvector-enforcer-pod
+```
+
++ Wait for the restart to complete
+
+```bash
+kubectl rollout status deployment neuvector-controller-pod
+kubectl rollout status deployment neuvector-scanner-pod
+kubectl rollout status deployment neuvector-registry-adapter-pod 
+kubectl rollout status ds neuvector-enforcer-pod
+```
+
++ Make sure the console can be accessed and controllers are all online.
+
++ Update the Kubernetes secret with the new `ca.crt`
 
 ```bash
 kubectl delete secret internal-cert -n neuvector

--- a/docs/02.deploying/01.production/04.internal/04.internal.md
+++ b/docs/02.deploying/01.production/04.internal/04.internal.md
@@ -15,7 +15,41 @@ WARNING: Replacing certificates is recommended to be performed only during initi
 
 #### Replacing Certificates Used in Internal Communications of NeuVector
 
-To replace the internal encryption files ca.crt, tls.key, tls.crt, first create the new ca.cfg file (see sample below). Then delete the relevant file, kubernetes secret, then generate new files and secret.
+Replace the internal encryption files `ca.crt`, `tls.key`, `tls.crt` as follows:
+
++ Create a new `ca.cfg` file with your favorite editor:
+
+```shell
+[req]
+distinguished_name = req_distinguished_name
+x509_extensions = v3_req
+prompt = no
+[req_distinguished_name]
+C = US
+ST = California
+L = San Jose
+O = NeuVector Inc.
+OU = Neuvector
+CN = Neuvector
+[v3_req]
+keyUsage = digitalSignature, keyEncipherment, dataEncipherment
+extendedKeyUsage = serverAuth, clientAuth
+subjectAltName = @alt_names
+[alt_names]
+DNS.1 = Neuvector
+```
+
+:::info
+For additional information on `ca.cfg`, see https://open-docs.neuvector.com/configuration/console/replacecert.
+:::
+
++ Choose your scenario from the three options below:
+
+<Tabs>
+<TabItem value="new_cert" label="New certificate">
+If your certificate is about to expire and you need to generate a new one, follow the steps below:
+
++ Delete the old `ca.crt`, `tls.key`, `tls.crt`, kubernetes secret, and generate new ones:
 
 ```bash
 kubectl delete secret internal-cert -n neuvector
@@ -24,8 +58,7 @@ openssl req -x509 -sha256 -new -nodes -key ca.key -days 3650 -out ca.crt
 openssl genrsa -out tls.key 2048
 openssl req -new -key tls.key -sha256 -out cert.csr -config ca.cfg
 openssl req -in cert.csr -noout -text
-openssl x509 -req -sha256 -in cert.csr -CA ca.crt -CAkey ca.key -CAcreateserial -out tls.crt -days 3650 -extfile ca.cfg
-    // for sample ca.cfg see below, or see https://open-docs.neuvector.com/configuration/console/replacecert
+openssl x509 -req -sha256 -in cert.csr -CA ca.crt -CAkey ca.key -CAcreateserial -out tls.crt -days 3650 -extensions 'v3_req' -extfile ca.cfg
 openssl x509 -in tls.crt -text
 kubectl create secret generic internal-cert -n neuvector  --from-file=tls.key --from-file=tls.crt --from-file=ca.crt
 ```
@@ -57,28 +90,6 @@ Then edit the Controller, Enforcer, and Scanner deployment yamls, adding:
 
 Then proceed to deploy NeuVector as before. You can also shell into the controller/enforcer/scanner pods to confirm that the ca.crt, tls.key, tls.crt files are the customized ones and that the NeuVector communications are working using the new certificates.
 
-Sample ca.cfg file referenced above:
-
-```shell
-[req]
-distinguished_name = req_distinguished_name
-x509_extensions = v3_req
-prompt = no
-[req_distinguished_name]
-C = US
-ST = California
-L = San Jose
-O = NeuVector Inc.
-OU = Neuvector
-CN = Neuvector
-[v3_req]
-keyUsage = keyEncipherment, dataEncipherment
-extendedKeyUsage = serverAuth
-subjectAltName = @alt_names
-[alt_names]
-DNS.1 = *
-```
-
 Sample patch commands for controller (change namespace to cattle-neuvector-system if needed, and modify for use on enforcer, scanner):
 
 ```bash
@@ -88,6 +99,99 @@ kubectl patch deployment -n ${NAMESPACE} neuvector-controller-pod --type='json' 
 
 kubectl patch deployment -n ${NAMESPACE} neuvector-controller-pod --type='json' -p='[{"op": "add", "path": "/spec/template/spec/containers/0/volumeMounts", "value": [{"mountPath": "/etc/neuvector/certs/internal/cert.key", "name": "internal-cert", "readOnly": true, "subPath": "cert.key"}, {"mountPath": "/etc/neuvector/certs/internal/cert.pem", "name": "internal-cert", "readOnly": true, "subPath": "cert.pem"}, {"mountPath": "/etc/neuvector/certs/internal/ca.cert", "name": "internal-cert", "readOnly": true, "subPath": "ca.cert"} ] } ]'
 ```
+</TabItem>
+<TabItem value="update_cert" label="Update current certificate with SANs">
+If your certificate files were created before NeuVector version 5.3, you need to upate the certificate with at least one Subject Alternative Name, or SAN for short.
+
+If you still have the files `ca.key` and `ca.crt` accessible, run the commands as follows:
+
+```bash
+kubectl delete secret internal-cert -n neuvector
+openssl genrsa -out tls.key 2048
+openssl req -new -key tls.key -sha256 -out cert.csr -config ca-new.cfg
+openssl req -in cert.csr -noout -text
+openssl x509 -req -sha256 -in cert.csr -CA ca.crt -CAkey ca.key -CAcreateserial -out tls.crt -days 3650 -extensions 'v3_req' -extfile ca-new.cfg
+openssl x509 -in tls.crt -text
+kubectl create secret generic internal-cert -n neuvector  --from-file=tls.key --from-file=tls.crt --from-file=ca.crt
+```
+
+Once the certificate files have been updated, restart the deployments in order to use the updated certificate:
+
+```bash
+kubectl rollout restart deployment neuvector-controller-pod
+kubectl rollout restart deployment neuvector-scanner-pod
+kubectl rollout restart deployment neuvector-registry-adapter-pod 
+kubectl rollout restart ds neuvector-enforcer-pod
+
+```
+</TabItem>
+<TabItem value="regenarate_cert" label="Regenarate certificate files and add SANs">
+If your certificate files were created before NeuVector version 5.3, you need to upate the certificate with at least one Subject Alternative Name, or SAN for short.
+
+If you don´t have the files `ca.key` and `ca.crt` anymore, follow the steps below:
+
+
++ Backup your original certificate
+
+```bash
+kubectl get secret internal-cert -o yaml > internal-cert.yaml
+```
+
++ Export the existing internal-cert
+
+```bash
+kubectl get secret internal-cert -o json | jq -r '.data."ca.crt"' | base64 -d > old-ca.crt
+kubectl get secret internal-cert -o json | jq -r '.data."tls.crt"' | base64 -d > old-tls.crt
+kubectl get secret internal-cert -o json | jq -r '.data."tls.key"' | base64 -d > old-tls.key
+```
+
++ Create new certificate files and internal certificates
+
+```bash
+openssl genrsa -out ca.key 2048
+openssl req -x509 -sha256 -new -nodes -key ca.key -days 3650 -out ca.crt
+openssl genrsa -out tls.key 2048
+openssl req -new -key tls.key -sha256 -out cert.csr -config ca.cfg
+openssl req -in cert.csr -noout -text
+openssl x509 -req -sha256 -in cert.csr -CA ca.crt -CAkey ca.key -CAcreateserial -out tls.crt -days 3650 -extensions 'v3_req' -extfile ca.cfg
+openssl x509 -in tls.crt -text
+```
+
++ Update the certificate files on the host
+
+```bash
+cat old-ca.crt > /tmp/ca.crt
+cat ca.crt >> /tmp/ca.crt
+```
+
++ Update the Kubernetes secret
+
+```bash
+kubectl delete secret internal-cert -n neuvector
+kubectl create secret generic internal-cert -n neuvector  --from-file=tls.key=old-tls.key --from-file=tls.crt=old-tls.crt --from-file=ca.crt=/tmp/ca.crt
+```
+
++ Restart the deployments in order to use the updated certificate
+
+```bash
+kubectl rollout restart deployment neuvector-controller-pod
+kubectl rollout restart deployment neuvector-scanner-pod
+kubectl rollout restart deployment neuvector-registry-adapter-pod 
+kubectl rollout restart ds neuvector-enforcer-pod
+```
+
++ Wait for the restart to complete
+
+```bash
+kubectl rollout status deployment neuvector-controller-pod
+kubectl rollout status deployment neuvector-scanner-pod
+kubectl rollout status deployment neuvector-registry-adapter-pod 
+kubectl rollout status ds neuvector-enforcer-pod
+```
+
++ Make sure the console can be accessed and controllers are all online.
+</TabItem>
+</Tabs>
 
 #### Updating/Deploying with Helm
 

--- a/versioned_docs/version-5.3/02.deploying/01.production/04.internal/04.internal.md
+++ b/versioned_docs/version-5.3/02.deploying/01.production/04.internal/04.internal.md
@@ -9,13 +9,49 @@ slug: /deploying/production/internal
 
 NeuVector includes default self-signed certificates for encryption for the Manager (console/UI access), Controller (REST API, internal), Enforcer (internal), and Scanner (internal) communications.
 
-These certificates can be replaced by your own to further harden communication. For replacing certificates used by external access to NeuVector (i.e, browser to the Manager, or REST API to the Controller), please see [this section](/configuration/console/replacecert/). See below for replacing the certificates used in internal communication between NeuVector containers.
+These certificates can be replaced by your own to further harden communication. For replacing certificates used by external access to NeuVector (i.e, browser to the Manager, or REST API to the Controller), please see [this section](../../configuration/console/replacecert/). See below for replacing the certificates used in internal communication between NeuVector containers.
 
-WARNING: Replacing certificates is recommended to be performed only during initial deployment of NeuVector. Replacing on a running cluster (even with rolling upgrade) may result in an unstable state where NeuVector pods are unable to communicate with each other due to a mismatch in certificates, and DATA LOSS may occur.
+:::danger warning
+Replacing certificates is recommended to be performed only during initial deployment of NeuVector. Replacing on a running cluster (even with rolling upgrade) may result in an unstable state where NeuVector pods are unable to communicate with each other due to a mismatch in certificates, and DATA LOSS may occur.
+:::
 
 #### Replacing Certificates Used in Internal Communications of NeuVector
 
-To replace the internal encryption files ca.crt, tls.key, tls.crt, first create the new ca.cfg file (see sample below). Then delete the relevant file, kubernetes secret, then generate new files and secret.
+Replace the internal encryption files `ca.crt`, `tls.key`, `tls.crt` as follows:
+
++ Create a new `ca.cfg` file with your favorite editor:
+
+```shell
+[req]
+distinguished_name = req_distinguished_name
+x509_extensions = v3_req
+prompt = no
+[req_distinguished_name]
+C = US
+ST = California
+L = San Jose
+O = NeuVector Inc.
+OU = Neuvector
+CN = Neuvector
+[v3_req]
+keyUsage = digitalSignature, keyEncipherment, dataEncipherment
+extendedKeyUsage = serverAuth, clientAuth
+subjectAltName = @alt_names
+[alt_names]
+DNS.1 = Neuvector
+```
+
+:::info
+For additional information on `ca.cfg`, see https://open-docs.neuvector.com/configuration/console/replacecert.
+:::
+
++ Choose your scenario from the three options below:
+
+<Tabs>
+<TabItem value="new_cert" label="New certificate">
+If your certificate is about to expire and you need to generate a new one, follow the steps below:
+
++ Delete the old `ca.crt`, `tls.key`, `tls.crt`, kubernetes secret, and generate new ones:
 
 ```bash
 kubectl delete secret internal-cert -n neuvector
@@ -24,8 +60,7 @@ openssl req -x509 -sha256 -new -nodes -key ca.key -days 3650 -out ca.crt
 openssl genrsa -out tls.key 2048
 openssl req -new -key tls.key -sha256 -out cert.csr -config ca.cfg
 openssl req -in cert.csr -noout -text
-openssl x509 -req -sha256 -in cert.csr -CA ca.crt -CAkey ca.key -CAcreateserial -out tls.crt -days 3650 -extfile ca.cfg
-    // for sample ca.cfg see below, or see https://open-docs.neuvector.com/configuration/console/replacecert
+openssl x509 -req -sha256 -in cert.csr -CA ca.crt -CAkey ca.key -CAcreateserial -out tls.crt -days 3650 -extensions 'v3_req' -extfile ca.cfg
 openssl x509 -in tls.crt -text
 kubectl create secret generic internal-cert -n neuvector  --from-file=tls.key --from-file=tls.crt --from-file=ca.crt
 ```
@@ -57,28 +92,6 @@ Then edit the Controller, Enforcer, and Scanner deployment yamls, adding:
 
 Then proceed to deploy NeuVector as before. You can also shell into the controller/enforcer/scanner pods to confirm that the ca.crt, tls.key, tls.crt files are the customized ones and that the NeuVector communications are working using the new certificates.
 
-Sample ca.cfg file referenced above:
-
-```shell
-[req]
-distinguished_name = req_distinguished_name
-x509_extensions = v3_req
-prompt = no
-[req_distinguished_name]
-C = US
-ST = California
-L = San Jose
-O = NeuVector Inc.
-OU = Neuvector
-CN = Neuvector
-[v3_req]
-keyUsage = keyEncipherment, dataEncipherment
-extendedKeyUsage = serverAuth
-subjectAltName = @alt_names
-[alt_names]
-DNS.1 = *
-```
-
 Sample patch commands for controller (change namespace to cattle-neuvector-system if needed, and modify for use on enforcer, scanner):
 
 ```bash
@@ -88,6 +101,99 @@ kubectl patch deployment -n ${NAMESPACE} neuvector-controller-pod --type='json' 
 
 kubectl patch deployment -n ${NAMESPACE} neuvector-controller-pod --type='json' -p='[{"op": "add", "path": "/spec/template/spec/containers/0/volumeMounts", "value": [{"mountPath": "/etc/neuvector/certs/internal/cert.key", "name": "internal-cert", "readOnly": true, "subPath": "cert.key"}, {"mountPath": "/etc/neuvector/certs/internal/cert.pem", "name": "internal-cert", "readOnly": true, "subPath": "cert.pem"}, {"mountPath": "/etc/neuvector/certs/internal/ca.cert", "name": "internal-cert", "readOnly": true, "subPath": "ca.cert"} ] } ]'
 ```
+</TabItem>
+<TabItem value="update_cert" label="Update current certificate with SANs">
+If your certificate files were created before NeuVector version 5.3, you need to upate the certificate with at least one Subject Alternative Name, or SAN for short.
+
+If you still have the files `ca.key` and `ca.crt` accessible, run the commands as follows:
+
+```bash
+kubectl delete secret internal-cert -n neuvector
+openssl genrsa -out tls.key 2048
+openssl req -new -key tls.key -sha256 -out cert.csr -config ca-new.cfg
+openssl req -in cert.csr -noout -text
+openssl x509 -req -sha256 -in cert.csr -CA ca.crt -CAkey ca.key -CAcreateserial -out tls.crt -days 3650 -extensions 'v3_req' -extfile ca-new.cfg
+openssl x509 -in tls.crt -text
+kubectl create secret generic internal-cert -n neuvector  --from-file=tls.key --from-file=tls.crt --from-file=ca.crt
+```
+
+Once the certificate files have been updated, restart the deployments in order to use the updated certificate:
+
+```bash
+kubectl rollout restart deployment neuvector-controller-pod
+kubectl rollout restart deployment neuvector-scanner-pod
+kubectl rollout restart deployment neuvector-registry-adapter-pod 
+kubectl rollout restart ds neuvector-enforcer-pod
+
+```
+</TabItem>
+<TabItem value="regenarate_cert" label="Regenarate certificate files and add SANs">
+If your certificate files were created before NeuVector version 5.3, you need to upate the certificate with at least one Subject Alternative Name, or SAN for short.
+
+If you don´t have the files `ca.key` and `ca.crt` anymore, follow the steps below:
+
+
++ Backup your original certificate
+
+```bash
+kubectl get secret internal-cert -o yaml > internal-cert.yaml
+```
+
++ Export the existing internal-cert
+
+```bash
+kubectl get secret internal-cert -o json | jq -r '.data."ca.crt"' | base64 -d > old-ca.crt
+kubectl get secret internal-cert -o json | jq -r '.data."tls.crt"' | base64 -d > old-tls.crt
+kubectl get secret internal-cert -o json | jq -r '.data."tls.key"' | base64 -d > old-tls.key
+```
+
++ Create new certificate files and internal certificates
+
+```bash
+openssl genrsa -out ca.key 2048
+openssl req -x509 -sha256 -new -nodes -key ca.key -days 3650 -out ca.crt
+openssl genrsa -out tls.key 2048
+openssl req -new -key tls.key -sha256 -out cert.csr -config ca.cfg
+openssl req -in cert.csr -noout -text
+openssl x509 -req -sha256 -in cert.csr -CA ca.crt -CAkey ca.key -CAcreateserial -out tls.crt -days 3650 -extensions 'v3_req' -extfile ca.cfg
+openssl x509 -in tls.crt -text
+```
+
++ Update the certificate files on the host
+
+```bash
+cat old-ca.crt > /tmp/ca.crt
+cat ca.crt >> /tmp/ca.crt
+```
+
++ Update the Kubernetes secret
+
+```bash
+kubectl delete secret internal-cert -n neuvector
+kubectl create secret generic internal-cert -n neuvector  --from-file=tls.key=old-tls.key --from-file=tls.crt=old-tls.crt --from-file=ca.crt=/tmp/ca.crt
+```
+
++ Restart the deployments in order to use the updated certificate
+
+```bash
+kubectl rollout restart deployment neuvector-controller-pod
+kubectl rollout restart deployment neuvector-scanner-pod
+kubectl rollout restart deployment neuvector-registry-adapter-pod 
+kubectl rollout restart ds neuvector-enforcer-pod
+```
+
++ Wait for the restart to complete
+
+```bash
+kubectl rollout status deployment neuvector-controller-pod
+kubectl rollout status deployment neuvector-scanner-pod
+kubectl rollout status deployment neuvector-registry-adapter-pod 
+kubectl rollout status ds neuvector-enforcer-pod
+```
+
++ Make sure the console can be accessed and controllers are all online.
+</TabItem>
+</Tabs>
 
 #### Updating/Deploying with Helm
 

--- a/versioned_docs/version-5.3/02.deploying/01.production/04.internal/04.internal.md
+++ b/versioned_docs/version-5.3/02.deploying/01.production/04.internal/04.internal.md
@@ -159,18 +159,72 @@ openssl x509 -req -sha256 -in cert.csr -CA ca.crt -CAkey ca.key -CAcreateserial 
 openssl x509 -in tls.crt -text
 ```
 
-+ Update the certificate files on the host
++ Merge the old and new `ca.crt` files
 
 ```bash
 cat old-ca.crt > /tmp/ca.crt
 cat ca.crt >> /tmp/ca.crt
 ```
 
-+ Update the Kubernetes secret
++ Update the Kubernetes secret with the merged `ca.crt`
 
 ```bash
 kubectl delete secret internal-cert -n neuvector
 kubectl create secret generic internal-cert -n neuvector  --from-file=tls.key=old-tls.key --from-file=tls.crt=old-tls.crt --from-file=ca.crt=/tmp/ca.crt
+```
+
++ Restart the deployments in order to use the updated certificate
+
+```bash
+kubectl rollout restart deployment neuvector-controller-pod
+kubectl rollout restart deployment neuvector-scanner-pod
+kubectl rollout restart deployment neuvector-registry-adapter-pod 
+kubectl rollout restart ds neuvector-enforcer-pod
+```
+
++ Wait for the restart to complete
+
+```bash
+kubectl rollout status deployment neuvector-controller-pod
+kubectl rollout status deployment neuvector-scanner-pod
+kubectl rollout status deployment neuvector-registry-adapter-pod 
+kubectl rollout status ds neuvector-enforcer-pod
+```
+
++ Make sure the console can be accessed and controllers are all online.
+
++ Update the Kubernetes secret with the new `tls.key`
+
+```bash
+kubectl delete secret internal-cert -n neuvector
+kubectl create secret generic internal-cert -n neuvector  --from-file=tls.key=tls.key --from-file=tls.crt=tls.crt --from-file=ca.crt=/tmp/ca.crt
+```
+
++ Restart the deployments in order to use the updated certificate
+
+```bash
+kubectl rollout restart deployment neuvector-controller-pod
+kubectl rollout restart deployment neuvector-scanner-pod
+kubectl rollout restart deployment neuvector-registry-adapter-pod 
+kubectl rollout restart ds neuvector-enforcer-pod
+```
+
++ Wait for the restart to complete
+
+```bash
+kubectl rollout status deployment neuvector-controller-pod
+kubectl rollout status deployment neuvector-scanner-pod
+kubectl rollout status deployment neuvector-registry-adapter-pod 
+kubectl rollout status ds neuvector-enforcer-pod
+```
+
++ Make sure the console can be accessed and controllers are all online.
+
++ Update the Kubernetes secret with the new `ca.crt`
+
+```bash
+kubectl delete secret internal-cert -n neuvector
+kubectl create secret generic internal-cert -n neuvector  --from-file=tls.key=tls.key --from-file=tls.crt=tls.crt --from-file=ca.crt=ca.crt
 ```
 
 + Restart the deployments in order to use the updated certificate


### PR DESCRIPTION
The documentation on `Replacing Certificates Used in Internal Communications of NeuVector` has been updated with the addition of SANs.

Based on the scenario the users might have, the documentation has been split in 3 distinct parts.

Signed-off-by: Nuno do Carmo nuno.carmo@suse.com