### PR TITLE
docs(scanners): Add information about env vars to authenticate with nv controller api

### DIFF
--- a/docs/06.scanning/06.scanners/06.scanners.md
+++ b/docs/06.scanning/06.scanners/06.scanners.md
@@ -74,6 +74,7 @@ The following scanner environment variables can be used in the docker run comman
 - SCANNER_SCAN_LAYERS= true or false (to return layered scan results)
 - SCANNER_ON_DEMAND=true (required)
 - CLUSTER_JOIN_ADDR (optional), CLUSTER_JOIN_PORT (optional) - to send results to controller for use in Admission control rules (Kubernetes deployed controller).
+- SCANNER_CTRL_API_USERNAME (optional), SCANNER_CTRL_API_PASSWORD (optional) - used in conjunction with CLUSTER_JOIN_ADDR to authenticate with the specified username and password to the NeuVector Controller API.
 - CLUSTER_ADVERTISED_ADDR (optional) - if scanner is on different host than controller, to send results for use in Admission control rules (Kubernetes deployed controller).
 
 #### Host Scanning in Standalone Mode


### PR DESCRIPTION
When doing a standalone scan and using `CLUSTER_JOIN_ADDR` to submit scan results back to the NeuVector Controller API, the authentication fails because of a missing user and password. The relevant env vars `SCANNER_CTRL_API_USERNAME` and `SCANNER_CTRL_API_PASSWORD` are not mentioned in the documentation. They are only mentioned in a changelog entry: https://open-docs.neuvector.com/releasenotes/4x/#scanner-details.
This PR adds the information about them and what they are used for to the scanner usage description.