### PR TITLE
Restructure public cloud deploy section

### DIFF
--- a/docs/02.deploying/06.public-cloud/01.awsmarketplace/01.awsmarketplace.md
+++ b/docs/02.deploying/06.public-cloud/01.awsmarketplace/01.awsmarketplace.md
@@ -1,8 +1,8 @@
 ---
-title: AWS Marketplace Billing
+title: AWS Marketplace
 taxonomy:
     category: docs
-slug: /deploying/awsmarketplace
+slug: /deploying/public-cloud/awsmarketplace
 ---
 
 ### Deploy NeuVector from AWS Marketplace Pay-As-You-Go Listing

--- a/docs/02.deploying/06.public-cloud/02.azuremarketplace/02.azuremarketplace.md
+++ b/docs/02.deploying/06.public-cloud/02.azuremarketplace/02.azuremarketplace.md
@@ -1,8 +1,8 @@
 ---
-title: Azure Marketplace Billing
+title: Azure Marketplace
 taxonomy:
     category: docs
-slug: /deploying/azuremarketplace
+slug: /deploying/public-cloud/azuremarketplace
 ---
 
 ### Deploy NeuVector from Azure Marketplace Pay-As-You-Go Listing

--- a/docs/02.deploying/06.public-cloud/03.marketplace-faq/03.marketplace-faq.md
+++ b/docs/02.deploying/06.public-cloud/03.marketplace-faq/03.marketplace-faq.md
@@ -1,25 +1,22 @@
 ---
-title: Public Cloud Marketplaces
+title: Public Cloud Marketplace FAQs
 taxonomy:
     category: docs
-slug: /special/public-cloud
+slug: /deploying/public-cloud/marketplace-faqs
 ---
 
 *NeuVector Prime by SUSE* is now available in the [AWS](https://aws.amazon.com/marketplace/pp/prodview-u2ciiono2w3h2) and [Azure Cloud](https://azuremarketplace.microsoft.com/en-us/marketplace/apps/neuvector.neuvector-app?tab=Overview) Marketplace.
 
 This brings the value of running NeuVector, the cloud-native, zero-trust container security platform, to cloud customers with the added benefit of a pay monthly pricing model available through the cloud marketplaces.
 
-This document covers some of the frequently asked questions about the listing in the following 4 categories:
+This document covers some of the frequently asked questions about the listing in the following categories:
 
 - [The Listing](#the-listing)
-
 - [Billing](#billing)
-
-- [Technical Billing](#technical-billing)
-
-- [Technical Product](#technical-product)
-
-- [Miscellaneous]
+- [Technical (Billing)](#technical-billing)
+- [Technical (Product)](#technical-product)
+- [Miscellaneous](#miscellaneous)
+- [Appendix](#appendix)
 
 ## The Listing
 
@@ -34,18 +31,18 @@ The listings can be found in the AWS and Azure Marketplace, there are two listin
 - For AWS Marketplace:
 
   - [NeuVector Prime with 24x7 Support (non-EU and non-UK only)](https://aws.amazon.com/marketplace/pp/prodview-u2ciiono2w3h2?sr=0-3&ref_=beagle&applicationId=AWSMPContessa)
-  
+
   - [NeuVector Prime with 24x7 Support (EU and UK only)](https://aws.amazon.com/marketplace/pp/prodview-xkfyjdvvkuohs)
 
 - For Azure Marketplace:
 
   - [NeuVector Prime with 24x7 Support (non-EU and non-UK only)](https://azuremarketplace.microsoft.com/en-us/marketplace/apps/suse.neuvector-prime-llc?tab=Overview)
-  
+
   - [NeuVector Prime with 24x7 Support (EU and UK only)](https://azuremarketplace.microsoft.com/en-us/marketplace/apps/suseirelandltd1692213356027.neuvector-prime-ltd?tab=Overview)
 
-***Why are there 2 listings, which one should I use?***
+***Why are there two listings, which one should I use?***
 
-We have 2 listings for NeuVector Prime, in AWS "EU and UK only" and "non-EU and non-UK only" and in Azure "24x7 Support" and "24x7 Support (EMEA Orders Only)", you should pick the listing that reflects where your **cloud account gets billed**.
+There are two listings for NeuVector Prime, in AWS "EU and UK only" and "non-EU and non-UK only" and in Azure "24x7 Support" and "24x7 Support (EMEA Orders Only)", you should pick the listing that reflects where your **cloud account gets billed**.
 
 ***Are these listings available in all countries?***
 
@@ -260,11 +257,11 @@ NeuVector is updated with major, minor, or patch versions every 6-8 weeks. To up
 
 - For AWS:
 
-  - You can find out more about the NeuVector Prime AWS Marketplace listing in the [NeuVector documentation](../deploying/awsmarketplace).
+  - You can find out more about the NeuVector Prime AWS Marketplace listing in the [NeuVector documentation](../deploying/public-cloud/awsmarketplace).
 
 - For Azure:
 
-  - You can find out more about the NeuVector Prime AWS Marketplace listing in the [NeuVector documentation](../deploying/azuremarketplace).
+  - You can find out more about the NeuVector Prime AWS Marketplace listing in the [NeuVector documentation](../deploying/public-cloud/azuremarketplace).
 
 ***Where can I find out more about NeuVector?***
 

--- a/docs/02.deploying/06.public-cloud/03.marketplace-faq/03.marketplace-faq.md
+++ b/docs/02.deploying/06.public-cloud/03.marketplace-faq/03.marketplace-faq.md
@@ -183,7 +183,7 @@ The marketplace listing is tied to a specific version of NeuVector, usually the 
 
 Typically, the marketplace listing is updated quarterly, or more frequently if there are security issues. NeuVector itself is updated with major, minor, or patch versions every 6-8 weeks.
 
-To update the NeuVector product to a current version before the marketplace listing is updated, please see [Updating NeuVector](../updating/updating).
+To update the NeuVector product to a current version before the marketplace listing is updated, please see [Updating NeuVector](../../updating/updating).
 
 ***I have many Kubernetes clusters across multiple cloud accounts, does the NeuVector billing still work and enable tiered pricing?***
 
@@ -193,7 +193,7 @@ Billing is routed to the cloud provider account in which the primary cluster is 
 
 ***I have multiple independent clusters, each running a separate installation of the NeuVector Prime marketplace listing, how is this billed?***
 
-As the NeuVector deployments are independent, each cluster is billed separately from the others. It is not possible to benefit from tiered pricing across clusters unless the NeuVector deployments are federated. Federation requires that only the primary cluster (not downstream remotes) be installed with the NeuVector Prime marketplace listing. Learn more about federation in [Enterprise Multi-Cluster Management](../navigation/multicluster).
+As the NeuVector deployments are independent, each cluster is billed separately from the others. It is not possible to benefit from tiered pricing across clusters unless the NeuVector deployments are federated. Federation requires that only the primary cluster (not downstream remotes) be installed with the NeuVector Prime marketplace listing. Learn more about federation in [Enterprise Multi-Cluster Management](../../navigation/multicluster).
 
 If Federation is not possible, consider custom terms from SUSE.
 
@@ -202,7 +202,7 @@ If Federation is not possible, consider custom terms from SUSE.
 The primary cluster must be running on a managed kubernetes cluster. This is EKS in the AWS Cloud, or AKS in Azure. The cluster must be running the NeuVector Prime marketplace listing.
 
 :::warning attention
-There MUST be network connectivity between the controllers in each cluster on the required ports. The controller is exposed externally to its cluster by either a primary or remote service. See [Enterprise Multi-Cluster Management](../navigation/multicluster) for more information on federating clusters.
+There MUST be network connectivity between the controllers in each cluster on the required ports. The controller is exposed externally to its cluster by either a primary or remote service. See [Enterprise Multi-Cluster Management](../../navigation/multicluster) for more information on federating clusters.
 :::
 
 ***I have purchased multiple SUSE products from the public cloud marketplace (e.g., Rancher Prime and NeuVector Prime), does the marketplace billing method still work?***
@@ -215,7 +215,7 @@ Yes, providing it is an EKS cluster in AWS, or AKS in Azure. Simply deploy the A
 
 ***I already have an existing cluster with NeuVector deployed, can I just install the NeuVector Prime marketplace listing and have support billed via the cloud marketplace?***
 
-Yes. This is possible by redeploying the NeuVector Prime from the cloud provider marketplace listing. Please follow the documentation to [back up the existing NeuVector configuration](../deploying/production#backups-and-persistent-data), as it may be necessary to [restore the configuration](../deploying/restore) into the new deployment.
+Yes. This is possible by redeploying the NeuVector Prime from the cloud provider marketplace listing. Please follow the documentation to [back up the existing NeuVector configuration](../../deploying/production#backups-and-persistent-data), as it may be necessary to [restore the configuration](../../deploying/restore) into the new deployment.
 
 ## Technical (Product)
 
@@ -249,7 +249,7 @@ Depending on when in the month the primary cluster gets reconnected you may have
 
 ***How do I get fixes and updates to NeuVector?***
 
-NeuVector is updated with major, minor, or patch versions every 6-8 weeks. To update NeuVector to a current version before the NeuVector Prime marketplace listing is updated, please see [Updating NeuVector](../updating/updating).
+NeuVector is updated with major, minor, or patch versions every 6-8 weeks. To update NeuVector to a current version before the NeuVector Prime marketplace listing is updated, please see [Updating NeuVector](../../updating/updating).
 
 ## Miscellaneous
 
@@ -257,11 +257,11 @@ NeuVector is updated with major, minor, or patch versions every 6-8 weeks. To up
 
 - For AWS:
 
-  - You can find out more about the NeuVector Prime AWS Marketplace listing in the [NeuVector documentation](../deploying/public-cloud/awsmarketplace).
+  - You can find out more about the NeuVector Prime AWS Marketplace listing in the [NeuVector documentation](awsmarketplace).
 
 - For Azure:
 
-  - You can find out more about the NeuVector Prime AWS Marketplace listing in the [NeuVector documentation](../deploying/public-cloud/azuremarketplace).
+  - You can find out more about the NeuVector Prime AWS Marketplace listing in the [NeuVector documentation](azuremarketplace).
 
 ***Where can I find out more about NeuVector?***
 

--- a/docs/02.deploying/06.public-cloud/06.public-cloud.md
+++ b/docs/02.deploying/06.public-cloud/06.public-cloud.md
@@ -1,14 +1,14 @@
 ---
-title: Public Cloud K8s AKS, EKS, GKE, IBM...
+title: Public Cloud Kubernetes Services
 taxonomy:
     category: docs
-slug: /deploying/publick8s
+slug: /deploying/public-cloud
 ---
 
 
 ### Deploy NeuVector on a Public Cloud Kubernetes Service
 
-Deploy NeuVector on any public cloud K8s service such as AWS EKS, Azure AKS, IBM Cloud K8s, Google Cloud, Alibaba Cloud or Oracle Cloud. 
+Deploy NeuVector on any public cloud Kubernetes service such as AWS EKS, Azure AKS, IBM Cloud K8s, Google Cloud, Alibaba Cloud or Oracle Cloud. 
 NeuVector has passed the Amazon EKS Anywhere Conformance and Validation Framework and, as such, is a validated solution and is available as an Add-on for EKS-Anywhere on Snowball Edge devices through the AWS Console.
 
 First, create your K8s cluster and confirm access with `kubectl get nodes`.


### PR DESCRIPTION
Moved all pages related to deploying in a public cloud under a single point in the deploying section. 

Minor tweaks to text to fix links and routing.