### PR TITLE
Multiple changes for v5.4.0 documentation

### DIFF
--- a/docs/14.releasenotes/01.5x/01.5x.md
+++ b/docs/14.releasenotes/01.5x/01.5x.md
@@ -164,7 +164,7 @@ metadata:
 spec:
   leaseTransitions: 0
 EOF
-
+```bash
 #### 5.3.4 July 2024
 
 ##### Bug Fixes

--- a/docs/14.releasenotes/01.5x/01.5x.md
+++ b/docs/14.releasenotes/01.5x/01.5x.md
@@ -164,7 +164,8 @@ metadata:
 spec:
   leaseTransitions: 0
 EOF
-```bash
+```
+
 #### 5.3.4 July 2024
 
 ##### Bug Fixes

--- a/versioned_docs/version-5.4/02.deploying/02.kubernetes/02.kubernetes.md
+++ b/versioned_docs/version-5.4/02.deploying/02.kubernetes/02.kubernetes.md
@@ -1,4 +1,5 @@
----
+
+kubectl create rolebinding neuvector-binding-lease --role=neuvector-binding-lease --serviceaccount=neuvector:controller --serviceaccount=neuvector:cert-upgrader -n neuvector---
 title: Kubernetes 
 taxonomy:
     category: docs
@@ -134,17 +135,17 @@ kubectl create clusterrolebinding neuvector-binding-nvadmissioncontrolsecurityru
 kubectl create clusterrolebinding neuvector-binding-nvdlpsecurityrules --clusterrole=neuvector-binding-nvdlpsecurityrules --serviceaccount=neuvector:controller
 kubectl create role neuvector-binding-scanner --verb=get,patch,update,watch --resource=deployments -n neuvector
 kubectl create rolebinding neuvector-binding-scanner --role=neuvector-binding-scanner --serviceaccount=neuvector:updater --serviceaccount=neuvector:controller -n neuvector
-kubectl create role neuvector-binding-secret --verb=get --resource=secrets -n neuvector
-kubectl create rolebinding neuvector-binding-secret --role=neuvector-binding-secret --serviceaccount=neuvector:controller -n neuvector
+kubectl create role neuvector-binding-secret --verb=get,list,watch --resource=secrets -n neuvector
+kubectl create rolebinding neuvector-binding-secret --role=neuvector-binding-secret --serviceaccount=neuvector:controller --serviceaccount=neuvector:enforcer --serviceaccount=neuvector:scanner --serviceaccount=neuvector:registry-adapter -n neuvector
 kubectl create clusterrole neuvector-binding-nvcomplianceprofiles --verb=get,list,delete --resource=nvcomplianceprofiles
 kubectl create clusterrolebinding neuvector-binding-nvcomplianceprofiles --clusterrole=neuvector-binding-nvcomplianceprofiles --serviceaccount=neuvector:controller
 kubectl create clusterrole neuvector-binding-nvvulnerabilityprofiles --verb=get,list,delete --resource=nvvulnerabilityprofiles
 kubectl create clusterrolebinding neuvector-binding-nvvulnerabilityprofiles --clusterrole=neuvector-binding-nvvulnerabilityprofiles --serviceaccount=neuvector:controller
-kubectl apply -f -f https://raw.githubusercontent.com/neuvector/manifests/main/kubernetes/5.4.0/neuvector-roles-k8s.yaml
+kubectl apply -f https://raw.githubusercontent.com/neuvector/manifests/main/kubernetes/5.4.0/neuvector-roles-k8s.yaml
 kubectl create role neuvector-binding-lease --verb=create,get,update --resource=leases -n neuvector
 kubectl create rolebinding neuvector-binding-cert-upgrader --role=neuvector-binding-cert-upgrader --serviceaccount=neuvector:cert-upgrader -n neuvector
 kubectl create rolebinding neuvector-binding-job-creation --role=neuvector-binding-job-creation --serviceaccount=neuvector:controller -n neuvector
-kubectl create rolebinding neuvector-binding-lease --role=neuvector-binding-lease --serviceaccount=neuvector:controller,neuvector:cert-upgrader -n neuvector
+kubectl create rolebinding neuvector-binding-lease --role=neuvector-binding-lease --serviceaccount=neuvector:controller --serviceaccount=neuvector:cert-upgrader -n neuvector
 ```
 
 </li>

--- a/versioned_docs/version-5.4/02.deploying/02.kubernetes/02.kubernetes.md
+++ b/versioned_docs/version-5.4/02.deploying/02.kubernetes/02.kubernetes.md
@@ -23,9 +23,9 @@ There is a separate section for OpenShift instructions, and Docker EE on Kuberne
 
 The images are on the NeuVector Docker Hub registry. Use the appropriate version tag for the manager, controller, enforcer, and leave the version as 'latest' for scanner and updater. For example:
 
-+ neuvector/manager:5.3.2
-+ neuvector/controller:5.3.2
-+ neuvector/enforcer:5.3.2
++ neuvector/manager:5.4.0
++ neuvector/controller:5.4.0
++ neuvector/enforcer:5.4.0
 + neuvector/scanner:latest
 + neuvector/updater:latest
 
@@ -55,6 +55,7 @@ kubectl create sa basic -n neuvector
 kubectl create sa updater -n neuvector
 kubectl create sa scanner -n neuvector
 kubectl create sa registry-adapter -n neuvector
+kubectl create sa cert-upgrader -n neuvector
 ```
 </li>
 <li>
@@ -78,12 +79,12 @@ kubectl label  namespace neuvector "pod-security.kubernetes.io/enforce=privilege
 Create the custom resources (CRD) for NeuVector security rules. For Kubernetes 1.19+:
 
 ```shell
-kubectl apply -f https://raw.githubusercontent.com/neuvector/manifests/main/kubernetes/5.3.0/crd-k8s-1.19.yaml
-kubectl apply -f https://raw.githubusercontent.com/neuvector/manifests/main/kubernetes/5.3.0/waf-crd-k8s-1.19.yaml
-kubectl apply -f https://raw.githubusercontent.com/neuvector/manifests/main/kubernetes/5.3.0/dlp-crd-k8s-1.19.yaml
-kubectl apply -f https://raw.githubusercontent.com/neuvector/manifests/main/kubernetes/5.3.0/com-crd-k8s-1.19.yaml
-kubectl apply -f https://raw.githubusercontent.com/neuvector/manifests/main/kubernetes/5.3.0/vul-crd-k8s-1.19.yaml
-kubectl apply -f https://raw.githubusercontent.com/neuvector/manifests/main/kubernetes/5.3.0/admission-crd-k8s-1.19.yaml
+kubectl apply -f https://raw.githubusercontent.com/neuvector/manifests/main/kubernetes/5.4.0/crd-k8s-1.19.yaml
+kubectl apply -f https://raw.githubusercontent.com/neuvector/manifests/main/kubernetes/5.4.0/waf-crd-k8s-1.19.yaml
+kubectl apply -f https://raw.githubusercontent.com/neuvector/manifests/main/kubernetes/5.4.0/dlp-crd-k8s-1.19.yaml
+kubectl apply -f https://raw.githubusercontent.com/neuvector/manifests/main/kubernetes/5.4.0/com-crd-k8s-1.19.yaml
+kubectl apply -f https://raw.githubusercontent.com/neuvector/manifests/main/kubernetes/5.4.0/vul-crd-k8s-1.19.yaml
+kubectl apply -f https://raw.githubusercontent.com/neuvector/manifests/main/kubernetes/5.4.0/admission-crd-k8s-1.19.yaml
 ```
 </li>
 <li>
@@ -139,6 +140,11 @@ kubectl create clusterrole neuvector-binding-nvcomplianceprofiles --verb=get,lis
 kubectl create clusterrolebinding neuvector-binding-nvcomplianceprofiles --clusterrole=neuvector-binding-nvcomplianceprofiles --serviceaccount=neuvector:controller
 kubectl create clusterrole neuvector-binding-nvvulnerabilityprofiles --verb=get,list,delete --resource=nvvulnerabilityprofiles
 kubectl create clusterrolebinding neuvector-binding-nvvulnerabilityprofiles --clusterrole=neuvector-binding-nvvulnerabilityprofiles --serviceaccount=neuvector:controller
+kubectl apply -f -f https://raw.githubusercontent.com/neuvector/manifests/main/kubernetes/5.4.0/neuvector-roles-k8s.yaml
+kubectl create role neuvector-binding-lease --verb=create,get,update --resource=leases -n neuvector
+kubectl create rolebinding neuvector-binding-cert-upgrader --role=neuvector-binding-cert-upgrader --serviceaccount=neuvector:cert-upgrader -n neuvector
+kubectl create rolebinding neuvector-binding-job-creation --role=neuvector-binding-job-creation --serviceaccount=neuvector:controller -n neuvector
+kubectl create rolebinding neuvector-binding-lease --role=neuvector-binding-lease --serviceaccount=neuvector:controller,neuvector:cert-upgrader -n neuvector
 ```
 
 </li>
@@ -166,15 +172,20 @@ neuvector-binding-nvdlpsecurityrules                ClusterRole/neuvector-bindin
 
 And this command:
 
+
 ```shell
-kubectl get RoleBinding neuvector-binding-scanner -n neuvector -o wide
+kubectl get RoleBinding neuvector-binding-scanner neuvector-binding-cert-upgrader neuvector-binding-job-creation neuvector-binding-lease neuvector-binding-secret -n neuvector -o wide
 ```
 
 Sample output:
 
 ```shell
-NAME                        ROLE                             AGE   USERS   GROUPS   SERVICEACCOUNTS
-neuvector-binding-scanner   Role/neuvector-binding-scanner   70d                    neuvector/updater, neuvector/controller
+NAME                              ROLE                                   AGE    USERS   GROUPS   SERVICEACCOUNTS
+neuvector-binding-scanner         Role/neuvector-binding-scanner         8m8s                    neuvector/controller, neuvector/updater
+neuvector-binding-cert-upgrader   Role/neuvector-binding-cert-upgrader   8m8s                    neuvector/cert-upgrader
+neuvector-binding-job-creation    Role/neuvector-binding-job-creation    8m8s                    neuvector/controller
+neuvector-binding-lease           Role/neuvector-binding-lease           8m8s                    neuvector/controller, neuvector/cert-upgrader
+neuvector-binding-secret          Role/neuvector-binding-secret          8m8s                    neuvector/controller, neuvector/enforcer, neuvector/scanner, neuvector/registry-adapter
 ```
 </li>
 <li>
@@ -225,7 +236,7 @@ kubectl create -f nv_master_worker.yaml
 Create the primary NeuVector services and pods using the preset version commands or modify the sample yaml below. The preset version invoke a LoadBalancer for the NeuVector Console. If using the sample yaml file below replace the image names and &lt;version> tags for the manager, controller and enforcer image references in the yaml file. Also make any other modifications required for your deployment environment (such as LoadBalancer/NodePort/Ingress for manager access etc).
 
 ```shell
-kubectl apply -f https://raw.githubusercontent.com/neuvector/manifests/main/kubernetes/5.3.0/neuvector-k8s.yaml
+kubectl apply -f https://raw.githubusercontent.com/neuvector/manifests/main/kubernetes/5.4.0/neuvector-k8s.yaml
 ```
 
 Or, if modifying any of the above yaml or samples from below:
@@ -360,13 +371,13 @@ To update to a new version of NeuVector from the command line.
 For controller as Deployment (also do for manager)
 
 ```shell
-kubectl set image deployment/neuvector-controller-pod neuvector-controller-pod=neuvector/controller:2.4.1 -n neuvector
+kubectl set image deployment/neuvector-controller-pod neuvector-controller-pod=neuvector/controller:<version> -n neuvector
 ```
 
 For any container as a DaemonSet:
 
 ```shell
-kubectl set image -n neuvector ds/neuvector-enforcer-pod neuvector-enforcer-pod=neuvector/enforcer:2.4.1
+kubectl set image -n neuvector ds/neuvector-enforcer-pod neuvector-enforcer-pod=neuvector/enforcer:<version>
 ```
 
 To check the status of the rolling update:
@@ -527,7 +538,7 @@ spec:
       serviceAccount: basic
       containers:
         - name: neuvector-manager-pod
-          image: neuvector/manager:5.3.2
+          image: neuvector/manager:5.4.0
           env:
             - name: CTRL_SERVER_IP
               value: neuvector-svc-controller.neuvector
@@ -572,7 +583,7 @@ spec:
       serviceAccount: controller
       containers:
         - name: neuvector-controller-pod
-          image: neuvector/controller:5.3.2
+          image: neuvector/controller:5.4.0
           securityContext:
             runAsUser: 0
           readinessProbe:
@@ -653,7 +664,7 @@ spec:
       serviceAccount: enforcer
       containers:
         - name: neuvector-enforcer-pod
-          image: neuvector/enforcer:5.3.2
+          image: neuvector/enforcer:5.4.0
           securityContext:
             # the following two lines are required for k8s v1.19+. pls comment out both lines if version is pre-1.19. Otherwise, a validating data error message will show
             seccompProfile:
@@ -771,8 +782,6 @@ spec:
             image: neuvector/updater:latest
             imagePullPolicy: Always
             command:
-            - /bin/sh
-            - -c
             - TOKEN=`cat /var/run/secrets/kubernetes.io/serviceaccount/token`; /usr/bin/curl -kv -X PATCH -H "Authorization:Bearer $TOKEN" -H "Content-Type:application/strategic-merge-patch+json" -d '{"spec":{"template":{"metadata":{"annotations":{"kubectl.kubernetes.io/restartedAt":"'`date +%Y-%m-%dT%H:%M:%S%z`'"}}}}}' 'https://kubernetes.default/apis/apps/v1/namespaces/neuvector/deployments/neuvector-scanner-pod'
           restartPolicy: Never
 ```

--- a/versioned_docs/version-5.4/02.deploying/04.openshift/04.openshift.md
+++ b/versioned_docs/version-5.4/02.deploying/04.openshift/04.openshift.md
@@ -16,9 +16,9 @@ To deploy manually, first pull the appropriate NeuVector containers from the Neu
 #### NeuVector Images on Docker Hub
 
 <p>The images are on the NeuVector Docker Hub registry. Use the appropriate version tag for the manager, controller, enforcer, and leave the version as 'latest' for scanner and updater. For example:
-<li>neuvector/manager:5.3.0</li>
-<li>neuvector/controller:5.3.0</li>
-<li>neuvector/enforcer:5.3.0</li>
+<li>neuvector/manager:5.4.0</li>
+<li>neuvector/controller:5.4.0</li>
+<li>neuvector/enforcer:5.4.0</li>
 <li>neuvector/scanner:latest</li>
 <li>neuvector/updater:latest</li></p>
 <p>Please be sure to update the image references in appropriate yaml files.</p>
@@ -103,6 +103,7 @@ oc create sa basic -n neuvector
 oc create sa updater -n neuvector
 oc create sa scanner -n neuvector
 oc create sa registry-adapter -n neuvector
+oc create sa cert-upgrader -n neuvector
 oc -n neuvector adm policy add-scc-to-user privileged -z enforcer
 ```
 
@@ -179,7 +180,7 @@ system:openshift:scc:privileged   ClusterRole/system:openshift:scc:privileged   
 Run this command to check NeuVector service for Controller:
 
 ```shell
-oc get rolebinding system:openshift:scc:neuvector-scc-controller n neuvector -o wide
+oc get rolebinding system:openshift:scc:neuvector-scc-controller -n neuvector -o wide
 ```
 
 The output will look like
@@ -192,12 +193,12 @@ System:openshift:scc:neuvector-scc-controller   ClusterRole/system:openshift:scc
 6) Create the custom resources (CRD) for NeuVector security rules. For OpenShift 4.6+ (Kubernetes 1.19+):
 
 ```shell
-oc apply -f https://raw.githubusercontent.com/neuvector/manifests/main/kubernetes/5.3.0/crd-k8s-1.19.yaml
-oc apply -f https://raw.githubusercontent.com/neuvector/manifests/main/kubernetes/5.3.0/waf-crd-k8s-1.19.yaml
-oc apply -f https://raw.githubusercontent.com/neuvector/manifests/main/kubernetes/5.3.0/dlp-crd-k8s-1.19.yaml
-oc apply -f https://raw.githubusercontent.com/neuvector/manifests/main/kubernetes/5.3.0/com-crd-k8s-1.19.yaml
-oc apply -f https://raw.githubusercontent.com/neuvector/manifests/main/kubernetes/5.3.0/vul-crd-k8s-1.19.yaml
-oc apply -f https://raw.githubusercontent.com/neuvector/manifests/main/kubernetes/5.3.0/admission-crd-k8s-1.19.yaml
+oc apply -f https://raw.githubusercontent.com/neuvector/manifests/main/kubernetes/5.4.0/crd-k8s-1.19.yaml
+oc apply -f https://raw.githubusercontent.com/neuvector/manifests/main/kubernetes/5.4.0/waf-crd-k8s-1.19.yaml
+oc apply -f https://raw.githubusercontent.com/neuvector/manifests/main/kubernetes/5.4.0/dlp-crd-k8s-1.19.yaml
+oc apply -f https://raw.githubusercontent.com/neuvector/manifests/main/kubernetes/5.4.0/com-crd-k8s-1.19.yaml
+oc apply -f https://raw.githubusercontent.com/neuvector/manifests/main/kubernetes/5.4.0/vul-crd-k8s-1.19.yaml
+oc apply -f https://raw.githubusercontent.com/neuvector/manifests/main/kubernetes/5.4.0/admission-crd-k8s-1.19.yaml
 ```
 
 7) Add read permission to access the kubernetes API and OpenShift RBACs. IMPORTANT: The standard NeuVector 5.2+ deployment uses least-privileged service accounts instead of the default. See below if upgrading to 5.2+ from a version prior to 5.2.
@@ -242,12 +243,17 @@ oc create role neuvector-binding-scanner --verb=get,patch,update,watch --resourc
 oc adm policy add-role-to-user neuvector-binding-scanner system:serviceaccount:neuvector:updater system:serviceaccount:neuvector:controller -n neuvector --role-namespace neuvector
 oc create clusterrole neuvector-binding-co --verb=get,list --resource=clusteroperators
 oc adm policy add-cluster-role-to-user neuvector-binding-co system:serviceaccount:neuvector:enforcer system:serviceaccount:neuvector:controller
-oc create role neuvector-binding-secret --verb=get --resource=secrets -n neuvector
-oc adm policy add-role-to-user neuvector-binding-secret system:serviceaccount:neuvector:controller -n neuvector --role-namespace neuvector
+oc create role neuvector-binding-secret --verb=get,list,watch --resource=secrets -n neuvector
+oc adm policy add-role-to-user neuvector-binding-secret system:serviceaccount:neuvector:controller system:serviceaccount:neuvector:enforcer system:serviceaccount:neuvector:scanner system:serviceaccount:neuvector:registry-adapter -n neuvector --role-namespace neuvector
 oc create clusterrole neuvector-binding-nvcomplianceprofiles --verb=get,list,delete --resource=nvcomplianceprofiles
 oc create clusterrolebinding neuvector-binding-nvcomplianceprofiles --clusterrole=neuvector-binding-nvcomplianceprofiles --serviceaccount=neuvector:controller
 oc create clusterrole neuvector-binding-nvvulnerabilityprofiles --verb=get,list,delete --resource=nvvulnerabilityprofiles
 oc create clusterrolebinding neuvector-binding-nvvulnerabilityprofiles --clusterrole=neuvector-binding-nvvulnerabilityprofiles --serviceaccount=neuvector:controller
+oc apply -f https://raw.githubusercontent.com/neuvector/manifests/main/kubernetes/5.4.0/neuvector-roles-k8s.yaml
+oc create role neuvector-binding-lease --verb=create,get,update --resource=leases -n neuvector
+oc adm policy add-role-to-user neuvector-binding-cert-upgrader system:serviceaccount:neuvector:cert-upgrader -n neuvector --role-namespace neuvector
+oc adm policy add-role-to-user neuvector-binding-job-creation system:serviceaccount:neuvector:cert-upgrader -n neuvector --role-namespace neuvector
+oc adm policy add-role-to-user neuvector-binding-lease system:serviceaccount:neuvector:controller system:serviceaccount:neuvector:cert-upgrader -n neuvector --role-namespace neuvector
 ```
 
 8) Run the following command to check if the neuvector/controller, neuvector/enforcer and neuvector/updater service accounts are added successfully.
@@ -275,14 +281,18 @@ neuvector-binding-co                                ClusterRole/neuvector-bindin
 And this command:
 
 ```shell
-oc get RoleBinding neuvector-binding-scanner -n neuvector -o wide
+oc get RoleBinding neuvector-binding-scanner neuvector-binding-cert-upgrader neuvector-binding-job-creation neuvector-binding-lease neuvector-binding-secret -n neuvector -o wide
 ```
 
 Sample output:
 
 ```shell
-NAME                        ROLE                             AGE   USERS   GROUPS   SERVICEACCOUNTS
-neuvector-binding-scanner   Role/neuvector-binding-scanner   70d                    neuvector/updater, neuvector/controller
+NAME                              ROLE                                   AGE   USERS   GROUPS   SERVICEACCOUNTS
+neuvector-binding-scanner         Role/neuvector-binding-scanner         56m                    neuvector/controller, neuvector/updater
+neuvector-binding-cert-upgrader   Role/neuvector-binding-cert-upgrader   56m                    neuvector/cert-upgrader
+neuvector-binding-job-creation    Role/neuvector-binding-job-creation    56m                    neuvector/controller
+neuvector-binding-lease           Role/neuvector-binding-lease           56m                    neuvector/controller, neuvector/cert-upgrader
+neuvector-binding-secret          Role/neuvector-binding-secret          56m                    neuvector/controller, neuvector/enforcer, neuvector/scanner, neuvector/registry-adapter
 ```
 
 9) (<strong>Optional</strong>) Create the Federation Master and/or Remote Multi-Cluster Management Services. If you plan to use the multi-cluster management functions in NeuVector, one cluster must have the Federation Master service deployed, and each remote cluster must have the Federation Worker service. For flexibility, you may choose to deploy both Master and Worker services on each cluster so any cluster can be a master or remote.
@@ -351,7 +361,7 @@ The name of your default OpenShift registry might have changed from docker-regis
 Type NodePort is used for the fed-master and fed-worker services instead of LoadBalancer. You may need to adjust for your deployment.
 :::
 
-If using the CRI-O run-time, see this [CRI-O sample](https://raw.githubusercontent.com/neuvector/manifests/main/kubernetes/5.3.0/neuvector-crio-oc.yaml).
+If using the CRI-O run-time, see this [CRI-O sample](https://raw.githubusercontent.com/neuvector/manifests/main/kubernetes/5.4.0/neuvector-crio-oc.yaml).
 
 **Master Node Taints and Tolerations**
 


### PR DESCRIPTION
I have added multiple changes in v5.4.0 documentation. Here are those
1. Completed the bash code block for v5.4.0 workaround. Releases below v5.4.0 are wrapped inside the workaround code block
2. Updated Native K8s deployment instructions for NV YAML deployment. This PR from manifest should be merged https://github.com/neuvector/manifests/pull/39 in order this instructions to work.
3. Updated Openshift deployment instructions for NV
