### PR TITLE
Links to production page updated

### DIFF
--- a/versioned_docs/version-5.2/02.deploying/02.kubernetes/02.kubernetes.md
+++ b/versioned_docs/version-5.2/02.deploying/02.kubernetes/02.kubernetes.md
@@ -11,7 +11,7 @@ You can use Kubernetes to deploy separate manager, controller and enforcer conta
 
 The sample file will deploy one manager and 3 controllers. It will deploy an enforcer on every node as a daemonset. By default, the yaml sample below will deploy to the Master node as well.
 
-See the bottom section for specifying dedicated manager or controller nodes using node labels. Note: It is not recommended to deploy (scale) more than one manager behind a load balancer due to potential session state issues. If you plan to use a PersistentVolume claim to store the backup of NeuVector config files, please see the general Backup/Persistent Data section in the [Deploying NeuVector](/deploying/production#backups-and-persistent-data) overview.
+See the bottom section for specifying dedicated manager or controller nodes using node labels. Note: It is not recommended to deploy (scale) more than one manager behind a load balancer due to potential session state issues. If you plan to use a PersistentVolume claim to store the backup of NeuVector config files, please see the general Backup/Persistent Data section in the [Deploying NeuVector](production#backups-and-persistent-data) overview.
 
 If your deployment supports an integrated load balancer, change type NodePort to LoadBalancer for the console in the yaml file below.
 

--- a/versioned_docs/version-5.4/02.deploying/02.kubernetes/02.kubernetes.md
+++ b/versioned_docs/version-5.4/02.deploying/02.kubernetes/02.kubernetes.md
@@ -1,5 +1,4 @@
-
-kubectl create rolebinding neuvector-binding-lease --role=neuvector-binding-lease --serviceaccount=neuvector:controller --serviceaccount=neuvector:cert-upgrader -n neuvector---
+---
 title: Kubernetes 
 taxonomy:
     category: docs


### PR DESCRIPTION
The link to `production` page from `kubernetes` page under deployment section was not working.

The link needed to be updated, and a typo at the headers page level was also impacting the build.

Signed-off-by: Nuno do Carmo nuno.carmo@suse.com