### PR TITLE
Update 08.responserules.md - clarify response rule group supported

### DIFF
--- a/docs/05.policy/08.responserules/08.responserules.md
+++ b/docs/05.policy/08.responserules/08.responserules.md
@@ -13,7 +13,7 @@ Response Rules provide a flexible, customizable rule engine to automate response
 
 Creating a new Response Rule using the following:
 
-+ Group. A rule will apply to a container Group (address group is not supported, for example criteria address=x.x.x.x/x). Please see the section Run-Time Security Policy -> Groups for more details on Groups and how to create a new one if needed.
++ Group. A rule will apply to a container Group (address group is not supported, for example, criteria address=x.x.x.x/x). Please see the section [Run-Time Security Policy -> Groups](../04.groups/04.groups.md) for more details on Groups and how to create a new one if needed.
 + Category. This is the type of event, such as Security Event, or CVE vulnerability scan result.
 + Criteria. Specify one or more criteria. Each Category will have different criteria which can be applied. For example, by the event name, severity, or minimum number of high CVEs.
 + Action. Select one or more actions. Quarantine will block all network traffic in/out of a container. Webhook requires that a webhook endpoint be defined in Settings -> Configuration. Suppress log will prevent this event from being logged in Notifications.

--- a/docs/05.policy/08.responserules/08.responserules.md
+++ b/docs/05.policy/08.responserules/08.responserules.md
@@ -13,7 +13,7 @@ Response Rules provide a flexible, customizable rule engine to automate response
 
 Creating a new Response Rule using the following:
 
-+ Group. A rule will apply to a Group. Please see the section Run-Time Security Policy -> Groups for more details on Groups and how to create a new one if needed.
++ Group. A rule will apply to a container Group (address group is not supported, for example criteria address=x.x.x.x/x). Please see the section Run-Time Security Policy -> Groups for more details on Groups and how to create a new one if needed.
 + Category. This is the type of event, such as Security Event, or CVE vulnerability scan result.
 + Criteria. Specify one or more criteria. Each Category will have different criteria which can be applied. For example, by the event name, severity, or minimum number of high CVEs.
 + Action. Select one or more actions. Quarantine will block all network traffic in/out of a container. Webhook requires that a webhook endpoint be defined in Settings -> Configuration. Suppress log will prevent this event from being logged in Notifications.


### PR DESCRIPTION
Address groups like criteria of address=x.x.x.x/x is not supported for matching.