### PR TITLE
[NVSHAS-9680] Adding NeuVector/Rancher SSO Permission Resources Documentation

### DIFF
--- a/docs/02.deploying/03.rancher/03.rancher.md
+++ b/docs/02.deploying/03.rancher/03.rancher.md
@@ -74,6 +74,142 @@ Note in the above screen shot, two Rancher users admin and gkosaka have been aut
 It is recommended to login directly to the NeuVector console as admin/admin to manually change the admin password to a strong password. This will only change the NeuVector identity provider admin user password (you may see another admin user whose identify provider is Rancher). Alternatively, include a [ConfigMap as a secret](/deploying/production/configmap#protect-sensitive-data-using-a-secret) in the initial deployment from Rancher (see chart values for ConfigMap settings) to set the default admin password to a strong password.
 :::
 
+#### NeuVector/Rancher SSO Permission Resources
+
+The Rancher v2.9.2 UI provides for selecting NeuVector permission resources when creating `Global/Cluster/Project/Namespaces` roles. When a Rancher user is assigned a role with a NeuVector permission resource, the user's NeuVector SSO session is assigned the respective NeuVector permission accordingly. This is to provide SSO users with custom roles other than the reserved `admin/reader/fedAdmin/fedReader` roles.
+
+Below are the mapped permission resources used with applicable `Global/Cluster/Project/Namespaces` roles.
+
+##### Mapped Permission Resources for `Global/Cluster` Role
+
+:::note
+Users will need to manually add * (Verbs) / services/proxy (Resource) to NeuVector-related `Global/Cluster` Roles.
+:::
+
+API Groups:
+
+`permission.neuvector.com`
+
+Verbs:
+
+```shell
+get    // for read-only(i.e. view)
+*      // for read/write(i.e. modify)
+```
+
+Resources:
+
+NeuVector, Cluster Scoped
+
+```shell
+AdmissionControl
+Authentication
+CI Scan
+Cluster
+Federation
+Vulnerability
+```
+
+NeuVector, Namespaced
+  
+```shell
+AuditEvents
+Authorization
+Compliance
+Events
+Namespace
+RegistryScan
+RuntimePolicy
+RuntimeScan
+SecurityEvents
+SystemConfig
+```
+
+Resource display for Rancher `Global/Cluster` Role Template pages:
+
+apiGroup for NeuVector
+
+`api.neuvector.com`
+
+```shell
+[resource display]   [resource]
+--------------------------------------------------
+"All Permissions":   nv-perm.all-permissions
+"Admission Control": nv-perm.admctrl
+"Audit Events":      nv-perm.audit-events
+"Authentication":    nv-perm.authentication
+"Authorization":     nv-perm.authorization
+"CI Scan":           nv-perm.ci-scan
+"Compliance":        nv-perm.compliance
+"Events":            nv-perm.events
+"Federation":        nv-perm.fed
+"Registry Scan":     nv-perm.reg-scan
+"Runtime Policy":    nv-perm.rt-policy
+"Runtime Scan":      nv-perm.rt-scan
+"Security Events":   nv-perm.security-events
+"System Config":     nv-perm.config
+"Vulnerability Profile":     nv-perm.vulnerability
+```
+
+##### Mapped Permission Resources for `Project/Namespace` Role
+
+:::note
+Users will need to manually add * (Verbs) / services/proxy (Resource) to NeuVector-related `Project/Namespace` Roles.
+:::
+
+API Groups:
+
+`permission.neuvector.com`
+
+Verbs:
+
+```shell
+get    // for read-only(i.e. view)
+*      // for read/write(i.e. modify)
+```
+
+Resources:
+
+NeuVector, Namespaced
+  
+```shell
+AuditEvents
+Authorization
+Compliance
+Events
+Namespace
+RegistryScan
+RuntimePolicy
+RuntimeScan
+SecurityEvents
+SystemConfig
+```
+
+Resource display for Rancher `Project` Role Template pages:
+
+apiGroup for NeuVector
+
+`api.neuvector.com`
+
+:::note
+`nv-perm.fed` is not supported for Rancher `Project` Role Template.
+:::
+
+```shell
+[resource display]   [resource]
+--------------------------------------------------
+"All Permissions":   nv-perm.all-permissions
+"Audit Events":      nv-perm.audit-events
+"Authorization":     nv-perm.authorization
+"Compliance":        nv-perm.compliance
+"Events":            nv-perm.events
+"Registry Scan":     nv-perm.reg-scan
+"Runtime Policy":    nv-perm.rt-policy
+"Runtime Scan":      nv-perm.rt-scan
+"Security Events":   nv-perm.security-events
+"System Config":     nv-perm.config
+```
+
 #### Disabling NeuVector/Rancher SSO
 
 To disable the ability to login to NeuVector from Rancher Manager, go to Settings -> Configuration.

--- a/docs/02.deploying/03.rancher/03.rancher.md
+++ b/docs/02.deploying/03.rancher/03.rancher.md
@@ -125,32 +125,6 @@ SecurityEvents
 SystemConfig
 ```
 
-Resource display for Rancher `Global/Cluster` Role Template pages:
-
-apiGroup for NeuVector
-
-`api.neuvector.com`
-
-```shell
-[resource display]   [resource]
---------------------------------------------------
-"All Permissions":   nv-perm.all-permissions
-"Admission Control": nv-perm.admctrl
-"Audit Events":      nv-perm.audit-events
-"Authentication":    nv-perm.authentication
-"Authorization":     nv-perm.authorization
-"CI Scan":           nv-perm.ci-scan
-"Compliance":        nv-perm.compliance
-"Events":            nv-perm.events
-"Federation":        nv-perm.fed
-"Registry Scan":     nv-perm.reg-scan
-"Runtime Policy":    nv-perm.rt-policy
-"Runtime Scan":      nv-perm.rt-scan
-"Security Events":   nv-perm.security-events
-"System Config":     nv-perm.config
-"Vulnerability Profile":     nv-perm.vulnerability
-```
-
 ##### Mapped Permission Resources for `Project/Namespace` Role
 
 :::note
@@ -183,31 +157,6 @@ RuntimePolicy
 RuntimeScan
 SecurityEvents
 SystemConfig
-```
-
-Resource display for Rancher `Project` Role Template pages:
-
-apiGroup for NeuVector
-
-`api.neuvector.com`
-
-:::note
-`nv-perm.fed` is not supported for Rancher `Project` Role Template.
-:::
-
-```shell
-[resource display]   [resource]
---------------------------------------------------
-"All Permissions":   nv-perm.all-permissions
-"Audit Events":      nv-perm.audit-events
-"Authorization":     nv-perm.authorization
-"Compliance":        nv-perm.compliance
-"Events":            nv-perm.events
-"Registry Scan":     nv-perm.reg-scan
-"Runtime Policy":    nv-perm.rt-policy
-"Runtime Scan":      nv-perm.rt-scan
-"Security Events":   nv-perm.security-events
-"System Config":     nv-perm.config
 ```
 
 #### Disabling NeuVector/Rancher SSO

--- a/versioned_docs/version-5.4/02.deploying/03.rancher/03.rancher.md
+++ b/versioned_docs/version-5.4/02.deploying/03.rancher/03.rancher.md
@@ -74,6 +74,142 @@ Note in the above screen shot, two Rancher users admin and gkosaka have been aut
 It is recommended to login directly to the NeuVector console as admin/admin to manually change the admin password to a strong password. This will only change the NeuVector identity provider admin user password (you may see another admin user whose identify provider is Rancher). Alternatively, include a [ConfigMap as a secret](/deploying/production/configmap#protect-sensitive-data-using-a-secret) in the initial deployment from Rancher (see chart values for ConfigMap settings) to set the default admin password to a strong password.
 :::
 
+#### NeuVector/Rancher SSO Permission Resources
+
+The Rancher v2.9.2 UI provides for selecting NeuVector permission resources when creating `Global/Cluster/Project/Namespaces` roles. When a Rancher user is assigned a role with a NeuVector permission resource, the user's NeuVector SSO session is assigned the respective NeuVector permission accordingly. This is to provide SSO users with custom roles other than the reserved `admin/reader/fedAdmin/fedReader` roles.
+
+Below are the mapped permission resources used with applicable `Global/Cluster/Project/Namespaces` roles.
+
+##### Mapped Permission Resources for `Global/Cluster` Role
+
+:::note
+Users will need to manually add * (Verbs) / services/proxy (Resource) to NeuVector-related `Global/Cluster` Roles.
+:::
+
+API Groups:
+
+`permission.neuvector.com`
+
+Verbs:
+
+```shell
+get    // for read-only(i.e. view)
+*      // for read/write(i.e. modify)
+```
+
+Resources:
+
+NeuVector, Cluster Scoped
+
+```shell
+AdmissionControl
+Authentication
+CI Scan
+Cluster
+Federation
+Vulnerability
+```
+
+NeuVector, Namespaced
+  
+```shell
+AuditEvents
+Authorization
+Compliance
+Events
+Namespace
+RegistryScan
+RuntimePolicy
+RuntimeScan
+SecurityEvents
+SystemConfig
+```
+
+Resource display for Rancher `Global/Cluster` Role Template pages:
+
+apiGroup for NeuVector
+
+`api.neuvector.com`
+
+```shell
+[resource display]   [resource]
+--------------------------------------------------
+"All Permissions":   nv-perm.all-permissions
+"Admission Control": nv-perm.admctrl
+"Audit Events":      nv-perm.audit-events
+"Authentication":    nv-perm.authentication
+"Authorization":     nv-perm.authorization
+"CI Scan":           nv-perm.ci-scan
+"Compliance":        nv-perm.compliance
+"Events":            nv-perm.events
+"Federation":        nv-perm.fed
+"Registry Scan":     nv-perm.reg-scan
+"Runtime Policy":    nv-perm.rt-policy
+"Runtime Scan":      nv-perm.rt-scan
+"Security Events":   nv-perm.security-events
+"System Config":     nv-perm.config
+"Vulnerability Profile":     nv-perm.vulnerability
+```
+
+##### Mapped Permission Resources for `Project/Namespace` Role
+
+:::note
+Users will need to manually add * (Verbs) / services/proxy (Resource) to NeuVector-related `Project/Namespace` Roles.
+:::
+
+API Groups:
+
+`permission.neuvector.com`
+
+Verbs:
+
+```shell
+get    // for read-only(i.e. view)
+*      // for read/write(i.e. modify)
+```
+
+Resources:
+
+NeuVector, Namespaced
+  
+```shell
+AuditEvents
+Authorization
+Compliance
+Events
+Namespace
+RegistryScan
+RuntimePolicy
+RuntimeScan
+SecurityEvents
+SystemConfig
+```
+
+Resource display for Rancher `Project` Role Template pages:
+
+apiGroup for NeuVector
+
+`api.neuvector.com`
+
+:::note
+`nv-perm.fed` is not supported for Rancher `Project` Role Template.
+:::
+
+```shell
+[resource display]   [resource]
+--------------------------------------------------
+"All Permissions":   nv-perm.all-permissions
+"Audit Events":      nv-perm.audit-events
+"Authorization":     nv-perm.authorization
+"Compliance":        nv-perm.compliance
+"Events":            nv-perm.events
+"Registry Scan":     nv-perm.reg-scan
+"Runtime Policy":    nv-perm.rt-policy
+"Runtime Scan":      nv-perm.rt-scan
+"Security Events":   nv-perm.security-events
+"System Config":     nv-perm.config
+```
+
 #### Disabling NeuVector/Rancher SSO
 
 To disable the ability to login to NeuVector from Rancher Manager, go to Settings -> Configuration.

--- a/versioned_docs/version-5.4/02.deploying/03.rancher/03.rancher.md
+++ b/versioned_docs/version-5.4/02.deploying/03.rancher/03.rancher.md
@@ -125,32 +125,6 @@ SecurityEvents
 SystemConfig
 ```
 
-Resource display for Rancher `Global/Cluster` Role Template pages:
-
-apiGroup for NeuVector
-
-`api.neuvector.com`
-
-```shell
-[resource display]   [resource]
---------------------------------------------------
-"All Permissions":   nv-perm.all-permissions
-"Admission Control": nv-perm.admctrl
-"Audit Events":      nv-perm.audit-events
-"Authentication":    nv-perm.authentication
-"Authorization":     nv-perm.authorization
-"CI Scan":           nv-perm.ci-scan
-"Compliance":        nv-perm.compliance
-"Events":            nv-perm.events
-"Federation":        nv-perm.fed
-"Registry Scan":     nv-perm.reg-scan
-"Runtime Policy":    nv-perm.rt-policy
-"Runtime Scan":      nv-perm.rt-scan
-"Security Events":   nv-perm.security-events
-"System Config":     nv-perm.config
-"Vulnerability Profile":     nv-perm.vulnerability
-```
-
 ##### Mapped Permission Resources for `Project/Namespace` Role
 
 :::note
@@ -183,31 +157,6 @@ RuntimePolicy
 RuntimeScan
 SecurityEvents
 SystemConfig
-```
-
-Resource display for Rancher `Project` Role Template pages:
-
-apiGroup for NeuVector
-
-`api.neuvector.com`
-
-:::note
-`nv-perm.fed` is not supported for Rancher `Project` Role Template.
-:::
-
-```shell
-[resource display]   [resource]
---------------------------------------------------
-"All Permissions":   nv-perm.all-permissions
-"Audit Events":      nv-perm.audit-events
-"Authorization":     nv-perm.authorization
-"Compliance":        nv-perm.compliance
-"Events":            nv-perm.events
-"Registry Scan":     nv-perm.reg-scan
-"Runtime Policy":    nv-perm.rt-policy
-"Runtime Scan":      nv-perm.rt-scan
-"Security Events":   nv-perm.security-events
-"System Config":     nv-perm.config
 ```
 
 #### Disabling NeuVector/Rancher SSO


### PR DESCRIPTION
Adding documentation of mapped permission resources associated with NeuVector/Rancher SSO. Tied to NVSHAS-9680.