### PR TITLE
[NVSHAS-5843] Adding Documentation for Federated ConfigMap YAML

### DIFF
--- a/docs/02.deploying/01.production/01.configmap/01.configmap.md
+++ b/docs/02.deploying/01.production/01.configmap/01.configmap.md
@@ -13,13 +13,46 @@ The 'always_reload: true' setting can be added in any ConfigMap yaml to force re
 
 #### Complete Sample NeuVector ConfigMap (initcfg.yaml)
 
-The latest ConfigMap can be found [here](https://raw.githubusercontent.com/neuvector/manifests/main/kubernetes/5.3.0/initcfg.yaml).
+The latest ConfigMap can be found [here](https://raw.githubusercontent.com/neuvector/manifests/main/kubernetes/5.4.0/initcfg.yaml).
 
 The sample is also shown below. This contains all the settings available. Please remove the sections not needed and edit the sections needed. Note: If using configmap in a secret, see section below for formatting changes.
 
 ```yaml
 apiVersion: v1
 data:
+  fedinitcfg.yaml: |
+    # ============ this section is used for primary cluster ============ >>>
+    # Optional. If specified, it overwrites the cluster name specified in the system configuration in the sysinitcfg.yaml file
+    Cluster_Name: primary.cluster.local
+    # Required and must be the same on primary cluster and remote clusters
+    # It must be 36 characters long, i.e., 32 hex characters grouped as 8-4-4-4-12 and separated by four hyphens
+    Join_Token: 2be93d8f-d42a-44fc-9d33-7c1a6153066b
+    # Required: REST server/port of the neuvector-svc-controller-fed-master service
+    Primary_Rest_Info:
+      Server: 1.2.3.4
+      Port: 11443
+    # Optional. Supported value: https
+    Use_Proxy: ""
+    # Optional. Whether federal repo scan data deployment is enabled (for primary cluster only)
+    Deploy_Repo_Scan_Data: false
+    # <<< ============ this section is used for primary cluster ============
+    # ============ this section is used for remote cluster ============ >>>
+    # Optional. If specified, it overwrites the cluster name specified in the system configuration in the sysinitcfg.yaml file
+    Cluster_Name: remote.cluster.local
+    # Required and must be the same on primary cluster and remote clusters
+    # It must be 36 characters long, i.e., 32 hex characters grouped as 8-4-4-4-12 and separated by four hyphens
+    Join_Token: 2be93d8f-d42a-44fc-9d33-7c1a6153066b
+    # Required: REST server/port of the neuvector-svc-controller-fed-master service
+    Primary_Rest_Info:
+      Server: 4.3.2.1
+      Port: 11443
+    # Optional, for remote cluster only. REST server/port of the neuvector-svc-controller-fed-managed service
+    Managed_Rest_Info:
+      Server: 1.2.3.4
+      Port: 10443
+    # Optional. Supported value: https
+    Use_Proxy: ""
+    # <<< ============ this section is used for remote cluster ============
   passwordprofileinitcfg.yaml: |
     # Optional. true or false or empty string(false)
     always_reload: false
@@ -295,12 +328,8 @@ data:
       - event
       - security-event
       - audit
-    Syslog_in_json: 
-    # Optional. true, false, empty, unconfigured.
-    #  true = In Json: checkbox enabled from Settings > Configuration > Syslog
-    #  false, empty, unconfigured = In Json: checkbox disabled from Settings > Configuration > Syslog
-    #
     # Optional. true or false or empty string(false)
+    Syslog_in_json: false
     Auth_By_Platform: false
     single_cve_per_syslog: false
     syslog_cve_in_layers: false
@@ -310,9 +339,11 @@ data:
         url: http...
         type: Slack
         enable: true
+        use_proxy: false
       - name: mywebhook
         url: http...
         enable: true
+        use_proxy: false
     # Optional. empty string
     Cluster_Name: cluster.local
     # Optional. chose multiple between cpath/mutex/conn/scan/cluster or empty string
@@ -336,6 +367,7 @@ data:
     Xff_Enabled: true
     Net_Service_Status: false
     Net_Service_Policy_Mode: Discover
+    Disable_Net_Policy: false
     Scanner_Autoscale:
     # Optional. Choose between immediate or delayed or empty string
       Strategy: 
@@ -343,6 +375,14 @@ data:
       Max_Pods: 3
     # Optional. true or false or empty string(false)
     No_Telemetry_Report: false
+    # Optional. Mode Automation Discovery to Monitor. true or false or empty string(false)
+    Mode_Auto_D2M: false
+    # Optional. default value is 0. unit is seconds and range is between 3600 and 2592000 (1 hour to 30 days)
+    Mode_Auto_D2M_Duration: 0
+    # Optional. Mode Automation Monitor to Protect. true or false or empty string(false)
+    Mode_Auto_M2P: false
+    # Optional. default value is 0. unit is seconds and range is between 3600 and 2592000 (1 hour to 30 days)
+    Mode_Auto_M2P_Duration: 0
     Scan_Config:
       # Optional. true or false or empty string(false)
       Auto_Scan: false
@@ -391,6 +431,48 @@ Then create the ConfigMap object:
 
 ```shell
 kubectl create -f initcfg.yaml
+```
+
+#### Federated ConfigMap Examples (fedinitcfg.yaml)
+
+NeuVector v5.4.0 supports Federation automation through the ConfigMap. Below are example `fedinitcfg.yaml` configurations that can be applied to your primary and managed clusters depending on your use case.
+
+Example `fedinitcfg.yaml` for the primary cluster:
+
+```yaml
+# Optional. If specified, it overwrites the cluster name specified in system configuration
+Cluster_Name: cluster-primary-43
+# Required and must be the same on primary cluster and managed clusters
+# It must be 36 characters long, i.e., 32 hex characters grouped as 8-4-4-4-12 and separated by four hyphens
+Join_Token: 2be93d8f-d42a-44fc-9d33-7c1a6153066b
+# Required: REST server/port of the neuvector-svc-controller-fed-master service
+Primary_Rest_Info:
+    Server: 10.1.10.43
+    Port: 30020
+# Optional. Supported value: https
+Use_Proxy: ""
+# Optional. Whether federal repo scan data deployment is enabled (for primary cluster only)
+Deploy_Repo_Scan_Data: false
+```
+
+Example `fedinitcfg.yaml` for managed clusters:
+
+```yaml
+# Optional. If specified, it overwrites the cluster name specified in system configuration
+Cluster_Name: cluster-managed-42
+# Required and must be the same on primary cluster and managed clusters
+# It must be 36 characters long, i.e., 32 hex characters grouped as 8-4-4-4-12 and separated by four hyphens
+Join_Token: 2be93d8f-d42a-44fc-9d33-7c1a6153066b
+# Required: REST server/port of the neuvector-svc-controller-fed-master service
+Primary_Rest_Info:
+    Server: 10.1.10.43
+    Port: 30020
+# Optional, for managed cluster only. REST server/port of the neuvector-svc-controller-api service
+Managed_Rest_Info:
+    Server: 10.1.10.42
+    Port: 30010
+# Optional. Supported value: https
+Use_Proxy: ""
 ```
 
 ### Protect Sensitive Data Using a Secret

--- a/docs/02.deploying/01.production/01.configmap/01.configmap.md
+++ b/docs/02.deploying/01.production/01.configmap/01.configmap.md
@@ -41,14 +41,15 @@ data:
     Cluster_Name: remote.cluster.local
     # Required and must be the same on primary cluster and remote clusters
     # It must be 36 characters long, i.e., 32 hex characters grouped as 8-4-4-4-12 and separated by four hyphens
+    # The Join_Token specified in the remote cluster's fedinitcfg.yaml needs to be the same as the Join_Token specified in the primary cluster's fedinitcfg.yaml otherwise the auto-joining request will be declined by the primary cluster
     Join_Token: 2be93d8f-d42a-44fc-9d33-7c1a6153066b
     # Required: REST server/port of the neuvector-svc-controller-fed-master service
     Primary_Rest_Info:
-      Server: 4.3.2.1
+      Server: 1.2.3.4
       Port: 11443
     # Optional, for remote cluster only. REST server/port of the neuvector-svc-controller-fed-managed service
     Managed_Rest_Info:
-      Server: 1.2.3.4
+      Server: 4.3.2.1
       Port: 10443
     # Optional. Supported value: https
     Use_Proxy: ""

--- a/docs/11.automation/02.automation/02.automation.md
+++ b/docs/11.automation/02.automation/02.automation.md
@@ -1,28 +1,26 @@
 ---
 title: REST API and Automation
 taxonomy:
-  category: docs
+    category: docs
 slug: /automation/automation
 ---
 
 ### NeuVector Automation
 
 There are many automation features in NeuVector to support the entire CI/CD workflow, including:
-
-- Jenkins plug-in to automated scanning during build
-- Registry scanning to automate repository monitoring
-- Admission Control policies to allow/deny unauthorized deployments
-- CIS benchmarks automatically run on hosts
-- Helm chart on github for automated deployment on Kubernetes
-- Response rules to automate responses to security events
-- REST API for building automation of any NeuVector function
-- Accessing APIs in Managed Clusters
++ Jenkins plug-in to automated scanning during build
++ Registry scanning to automate repository monitoring
++ Admission Control policies to allow/deny unauthorized deployments
++ CIS benchmarks automatically run on hosts
++ Helm chart on github for automated deployment on Kubernetes
++ Response rules to automate responses to security events
++ REST API for building automation of any NeuVector function
 
 #### REST API
 
 The NeuVector solution can be managed using the REST API. Below are common examples of automation using the REST API. The REST API yaml doc is best viewed in the Swagger 2.0 viewer. The REST API documentation is below in a yaml file which is best viewed in a reader such as swagger.io.
 
-Latest update can be found [here](https://raw.githubusercontent.com/neuvector/neuvector/main/controller/api/apis.yaml). Also in the NeuVector GitHub source code [repo](https://github.com/neuvector/neuvector/blob/main/controller/api/apis.yaml). The apis.yaml from the main truck can include unreleased features. It is recommended to download the appropriate released version source code and extract the apis.yaml from the controller/api folder.
+Latest update can be found [here](https://raw.githubusercontent.com/neuvector/neuvector/main/controller/api/apis.yaml). Also in the NeuVector GitHub source code [repo](https://github.com/neuvector/neuvector/blob/main/controller/api/apis.yaml).  The apis.yaml from the main truck can include unreleased features.  It is recommended to download the appropriate released version source code and extract the apis.yaml from the controller/api folder.
 
 :::warning important
 If you are making REST API calls with username/password, please be sure make a DELETE call against /v1/auth when done. There is a maximum of 32 concurrent sessions for each user. If this is exceeded, an authentication failure will occur.
@@ -58,7 +56,7 @@ spec:
 If using type LoadBalancer, set the _controllerIP_ in the examples below to the external IP or URL for the loadbalancer.
 :::
 
-#### Authentication for REST API
+#### Authentication for REST API 
 
 The REST API supports two types of authentication: username/password and token. Both can be configured in Settings -> Users, API Keys & Roles, and be associated with default or custom roles to limit access privileges. The examples below show username/password based authentication where a token is created first, then used in subsequent REST API calls. If using a token, it can be used directly in each REST API call. Note: username based connections have a limited number of concurrent sessions, so it is important to delete the username token as shown below when finished. Token based authentication does not have a limit, but expire according to the time limit selected when created.
 
@@ -121,7 +119,6 @@ You may need to install jq
 ```bash
 sudo yum install jq
 ```
-
 :::
 
 For Kubernetes based deployments you can set the Controller IP as follows:
@@ -288,7 +285,7 @@ curl -s -k -H 'Content-Type: application/json' -H 'X-Auth-Token: $_TOKEN_' -d '{
 
 Then check the EULA again.
 
-#### Configure Registry Scanning
+#### Configure Registry Scanning 
 
 ```shell
 curl -k -H "Content-Type: application/json" -H "X-Auth-Token: $_TOKEN_" -d '{"request": {"registry": "https://registry.connect.redhat.com", "username": "username", "password": "password", "tag": "latest", "repository": "neuvector/enforcer"}}' "https://controller:port/v1/scan/repository"
@@ -458,7 +455,7 @@ while :; do
             0)
                 exit 0;
                 ;;
-            1)
+            1)  
                 counter=0
                 declare -a sniffs;
                 for pods in "${workloads[@]}"; do
@@ -546,7 +543,7 @@ curl  -k -H "Content-Type: application/json" -H "X-Auth-Token: $_TOKEN_"  "https
 cat system_setting.json | jq .config.controller_debug
 ```
 
-Logout
+Logout 
 
 ```
 echo `date +%Y%m%d_%H%M%S` log out
@@ -562,7 +559,7 @@ curl -k -H "Content-Type: application/json" -H "X-Auth-Token: $_TOKEN_" -d '{"re
 {noformat}
 ```
 
-<strong>Limitations:</strong> If the image to be scanned is a remote image, with "registry" specified, the base image must also be a remote image, and the name must start with http or https. If the image to be scanned is a local image, then the base image must also be a local image as well.
+<strong>Limitations:</strong> If the image to be scanned is a remote image, with "registry" specified, the base image must also be a remote image, and the name must start with http or https.  If the image to be scanned is a local image, then the base image must also be a local image as well. 
 
 For example,
 
@@ -582,22 +579,22 @@ Output:
 
 ```json
 {
-  "scanners": [
-    {
-      "cvedb_create_time": "2020-07-07T10:34:04Z",
-      "cvedb_version": "1.950",
-      "id": "0f043705948557828ac1831ee596588a0d050950113117ddd19ecd604982f4d9",
-      "port": 18402,
-      "server": "127.0.0.1"
-    },
-    {
-      "cvedb_create_time": "2020-07-07T10:34:04Z",
-      "cvedb_version": "1.950",
-      "id": "9fa02c644d603f59331c95735158d137002d32a75ed1014326f5039f38d4d717",
-      "port": 18402,
-      "server": "192.168.9.95"
-    }
-  ]
+    "scanners": [
+        {
+            "cvedb_create_time": "2020-07-07T10:34:04Z",
+            "cvedb_version": "1.950",
+            "id": "0f043705948557828ac1831ee596588a0d050950113117ddd19ecd604982f4d9",
+            "port": 18402,
+            "server": "127.0.0.1"
+        },
+        {
+            "cvedb_create_time": "2020-07-07T10:34:04Z",
+            "cvedb_version": "1.950",
+            "id": "9fa02c644d603f59331c95735158d137002d32a75ed1014326f5039f38d4d717",
+            "port": 18402,
+            "server": "192.168.9.95"
+        }
+    ]
 }
 ```
 
@@ -605,6 +602,8 @@ Output:
 
 Generally, listing Federation members can use a GET to the following endpoint (see samples for specific syntax):
 https://neuvector-svc-controller.neuvector:10443/v1/fed/member
+
+For information on Federation automation via ConfigMap view the [Federated ConfigMap Examples](../../02.deploying/01.production/01.configmap/01.configmap.md#federated-configmap-examples-fedinitcfgyaml) documentation.
 
 Selected Federation Management API's:
 
@@ -664,34 +663,3 @@ echo `date +%Y%m%d_%H%M%S` [$_curCase_] idle 9 seconds for events
 sleep 9
 #######################################################################
 ```
-
-#### Accessing APIs in Managed Clusters
-
-Step 1: Retrieve the Cluster ID
-
-To obtain the cluster ID, call the v1/fed/member API to list federation members.
-The response will include the id about the joint clusters, formatted as follows:
-
-```
-"joint_clusters": [
-    {
-        "disabled": false,
-        "id": "b284ed494351ffc1f7c0dbbe203848ef",
-        "name": "cluster.local",
-        ....
-    }
-]
-```
-
-In this example, the cluster ID you need is `b284ed494351ffc1f7c0dbbe203848ef`.
-
-Step 2: Make API Calls on the Managed Cluster
-
-To call an API on the managed cluster, use the cluster ID obtained in Step 1.
-For instance, if you want to call the `v1/user` API, structure your request as follows:
-
-`/v1/fed/cluster/$cluster_id/v1/user`
-Replace $cluster_id with the actual cluster ID retrieved in Step 1.
-
-To get the workload, it will be
-`v1/fed/cluster/$cluster_id/v1/workload`

--- a/versioned_docs/version-5.4/02.deploying/01.production/01.configmap/01.configmap.md
+++ b/versioned_docs/version-5.4/02.deploying/01.production/01.configmap/01.configmap.md
@@ -13,13 +13,46 @@ The 'always_reload: true' setting can be added in any ConfigMap yaml to force re
 
 #### Complete Sample NeuVector ConfigMap (initcfg.yaml)
 
-The latest ConfigMap can be found [here](https://raw.githubusercontent.com/neuvector/manifests/main/kubernetes/5.3.0/initcfg.yaml).
+The latest ConfigMap can be found [here](https://raw.githubusercontent.com/neuvector/manifests/main/kubernetes/5.4.0/initcfg.yaml).
 
 The sample is also shown below. This contains all the settings available. Please remove the sections not needed and edit the sections needed. Note: If using configmap in a secret, see section below for formatting changes.
 
 ```yaml
 apiVersion: v1
 data:
+  fedinitcfg.yaml: |
+    # ============ this section is used for primary cluster ============ >>>
+    # Optional. If specified, it overwrites the cluster name specified in the system configuration in the sysinitcfg.yaml file
+    Cluster_Name: primary.cluster.local
+    # Required and must be the same on primary cluster and remote clusters
+    # It must be 36 characters long, i.e., 32 hex characters grouped as 8-4-4-4-12 and separated by four hyphens
+    Join_Token: 2be93d8f-d42a-44fc-9d33-7c1a6153066b
+    # Required: REST server/port of the neuvector-svc-controller-fed-master service
+    Primary_Rest_Info:
+      Server: 1.2.3.4
+      Port: 11443
+    # Optional. Supported value: https
+    Use_Proxy: ""
+    # Optional. Whether federal repo scan data deployment is enabled (for primary cluster only)
+    Deploy_Repo_Scan_Data: false
+    # <<< ============ this section is used for primary cluster ============
+    # ============ this section is used for remote cluster ============ >>>
+    # Optional. If specified, it overwrites the cluster name specified in the system configuration in the sysinitcfg.yaml file
+    Cluster_Name: remote.cluster.local
+    # Required and must be the same on primary cluster and remote clusters
+    # It must be 36 characters long, i.e., 32 hex characters grouped as 8-4-4-4-12 and separated by four hyphens
+    Join_Token: 2be93d8f-d42a-44fc-9d33-7c1a6153066b
+    # Required: REST server/port of the neuvector-svc-controller-fed-master service
+    Primary_Rest_Info:
+      Server: 4.3.2.1
+      Port: 11443
+    # Optional, for remote cluster only. REST server/port of the neuvector-svc-controller-fed-managed service
+    Managed_Rest_Info:
+      Server: 1.2.3.4
+      Port: 10443
+    # Optional. Supported value: https
+    Use_Proxy: ""
+    # <<< ============ this section is used for remote cluster ============
   passwordprofileinitcfg.yaml: |
     # Optional. true or false or empty string(false)
     always_reload: false
@@ -295,12 +328,8 @@ data:
       - event
       - security-event
       - audit
-    Syslog_in_json: 
-    # Optional. true, false, empty, unconfigured.
-    #  true = In Json: checkbox enabled from Settings > Configuration > Syslog
-    #  false, empty, unconfigured = In Json: checkbox disabled from Settings > Configuration > Syslog
-    #
     # Optional. true or false or empty string(false)
+    Syslog_in_json: false
     Auth_By_Platform: false
     single_cve_per_syslog: false
     syslog_cve_in_layers: false
@@ -310,9 +339,11 @@ data:
         url: http...
         type: Slack
         enable: true
+        use_proxy: false
       - name: mywebhook
         url: http...
         enable: true
+        use_proxy: false
     # Optional. empty string
     Cluster_Name: cluster.local
     # Optional. chose multiple between cpath/mutex/conn/scan/cluster or empty string
@@ -336,6 +367,7 @@ data:
     Xff_Enabled: true
     Net_Service_Status: false
     Net_Service_Policy_Mode: Discover
+    Disable_Net_Policy: false
     Scanner_Autoscale:
     # Optional. Choose between immediate or delayed or empty string
       Strategy: 
@@ -343,6 +375,14 @@ data:
       Max_Pods: 3
     # Optional. true or false or empty string(false)
     No_Telemetry_Report: false
+    # Optional. Mode Automation Discovery to Monitor. true or false or empty string(false)
+    Mode_Auto_D2M: false
+    # Optional. default value is 0. unit is seconds and range is between 3600 and 2592000 (1 hour to 30 days)
+    Mode_Auto_D2M_Duration: 0
+    # Optional. Mode Automation Monitor to Protect. true or false or empty string(false)
+    Mode_Auto_M2P: false
+    # Optional. default value is 0. unit is seconds and range is between 3600 and 2592000 (1 hour to 30 days)
+    Mode_Auto_M2P_Duration: 0
     Scan_Config:
       # Optional. true or false or empty string(false)
       Auto_Scan: false
@@ -391,6 +431,48 @@ Then create the ConfigMap object:
 
 ```shell
 kubectl create -f initcfg.yaml
+```
+
+#### Federated ConfigMap Examples (fedinitcfg.yaml)
+
+NeuVector v5.4.0 supports Federation automation through the ConfigMap. Below are example `fedinitcfg.yaml` configurations that can be applied to your primary and managed clusters depending on your use case.
+
+Example `fedinitcfg.yaml` for the primary cluster:
+
+```yaml
+# Optional. If specified, it overwrites the cluster name specified in system configuration
+Cluster_Name: cluster-primary-43
+# Required and must be the same on primary cluster and managed clusters
+# It must be 36 characters long, i.e., 32 hex characters grouped as 8-4-4-4-12 and separated by four hyphens
+Join_Token: 2be93d8f-d42a-44fc-9d33-7c1a6153066b
+# Required: REST server/port of the neuvector-svc-controller-fed-master service
+Primary_Rest_Info:
+    Server: 10.1.10.43
+    Port: 30020
+# Optional. Supported value: https
+Use_Proxy: ""
+# Optional. Whether federal repo scan data deployment is enabled (for primary cluster only)
+Deploy_Repo_Scan_Data: false
+```
+
+Example `fedinitcfg.yaml` for managed clusters:
+
+```yaml
+# Optional. If specified, it overwrites the cluster name specified in system configuration
+Cluster_Name: cluster-managed-42
+# Required and must be the same on primary cluster and managed clusters
+# It must be 36 characters long, i.e., 32 hex characters grouped as 8-4-4-4-12 and separated by four hyphens
+Join_Token: 2be93d8f-d42a-44fc-9d33-7c1a6153066b
+# Required: REST server/port of the neuvector-svc-controller-fed-master service
+Primary_Rest_Info:
+    Server: 10.1.10.43
+    Port: 30020
+# Optional, for managed cluster only. REST server/port of the neuvector-svc-controller-api service
+Managed_Rest_Info:
+    Server: 10.1.10.42
+    Port: 30010
+# Optional. Supported value: https
+Use_Proxy: ""
 ```
 
 ### Protect Sensitive Data Using a Secret

--- a/versioned_docs/version-5.4/02.deploying/01.production/01.configmap/01.configmap.md
+++ b/versioned_docs/version-5.4/02.deploying/01.production/01.configmap/01.configmap.md
@@ -41,14 +41,15 @@ data:
     Cluster_Name: remote.cluster.local
     # Required and must be the same on primary cluster and remote clusters
     # It must be 36 characters long, i.e., 32 hex characters grouped as 8-4-4-4-12 and separated by four hyphens
+    # The Join_Token specified in the remote cluster's fedinitcfg.yaml needs to be the same as the Join_Token specified in the primary cluster's fedinitcfg.yaml otherwise the auto-joining request will be declined by the primary cluster
     Join_Token: 2be93d8f-d42a-44fc-9d33-7c1a6153066b
     # Required: REST server/port of the neuvector-svc-controller-fed-master service
     Primary_Rest_Info:
-      Server: 4.3.2.1
+      Server: 1.2.3.4
       Port: 11443
     # Optional, for remote cluster only. REST server/port of the neuvector-svc-controller-fed-managed service
     Managed_Rest_Info:
-      Server: 1.2.3.4
+      Server: 4.3.2.1
       Port: 10443
     # Optional. Supported value: https
     Use_Proxy: ""

--- a/versioned_docs/version-5.4/11.automation/02.automation/02.automation.md
+++ b/versioned_docs/version-5.4/11.automation/02.automation/02.automation.md
@@ -603,6 +603,8 @@ Output:
 Generally, listing Federation members can use a GET to the following endpoint (see samples for specific syntax):
 https://neuvector-svc-controller.neuvector:10443/v1/fed/member
 
+For information on Federation automation via ConfigMap view the [Federated ConfigMap Examples](../../02.deploying/01.production/01.configmap/01.configmap.md#federated-configmap-examples-fedinitcfgyaml) documentation.
+
 Selected Federation Management API's:
 
 ```bash


### PR DESCRIPTION
Adding documentation for the Federated ConfigMap primary and managed clusters. Also updated the latest ConfigMap link to https://raw.githubusercontent.com/neuvector/manifests/main/kubernetes/5.4.0/initcfg.yaml, and updated the sample `initcfg.yaml`. Related to NVSHAS-5843.