### PR TITLE
fix: update internal certificate documents

### DIFF
--- a/docs/02.deploying/01.production/04.internal/04.internal.md
+++ b/docs/02.deploying/01.production/04.internal/04.internal.md
@@ -5,6 +5,11 @@ taxonomy:
 slug: /deploying/production/internal
 ---
 
+:::note
+For versions prior to 5.4.2, after Mar. 2025, internal certificate has to be generated/replaced before using NeuVector.
+For versions of 5.4.2 and later, internal certificate has to be generated/replaced before using NeuVector.
+:::
+
 ### Internal Communication and Certificates
 
 NeuVector includes default self-signed certificates for encryption for the Manager (console/UI access), Controller (REST API, internal), Enforcer (internal), and Scanner (internal) communications.
@@ -244,6 +249,34 @@ kubectl rollout status ds neuvector-enforcer-pod
 ```
 
 + Make sure the console can be accessed and controllers are all online.
+</TabItem>
+<TabItem value="regenerate_cert_from_builtin" label="Regenerate certificate when built-in certificate is being used">
+If you didn't replace the internal certificate before and want to migrate to a new set of certificates, follow the steps below:
+
++ Check if you already have the internal certificate generated automatically.
+
+```bash
+kubectl get secret internal-cert -o yaml
+```
+
+If you see `tls.key`, `tls.crt` and `ca.crt` there, that means you've been using the automatically generated certificate and you can skip this section.
+
+If you can see the secret, but cannot find these secrets, consider enabling `internal.autoRotateCert` in the helm charts override. This option will generate and rotate your internal certificate automatically.
+
+If you don't use the automatically generated internal certificate and can't do so, follow the steps below:
+
++ Follow the steps in the `New certificate` tab to use a Kubernetes secret to manage the internal certificate. Instead of generating a new certificate, use the certificate, `old-ca.crt`, `old-tls.crt` and `old-tls.key`, retrieved below:
+
+```
+docker run -it --entrypoint=bash neuvector/scanner:3.654 -c "cat /etc/neuvector/certs/internal/ca.cert" > old-ca.crt
+docker run -it --entrypoint=bash neuvector/scanner:3.654 -c "cat /etc/neuvector/certs/internal/cert.pem" > old-tls.crt
+docker run -it --entrypoint=bash neuvector/scanner:3.654 -c "cat /etc/neuvector/certs/internal/cert.key" > old-tls.key
+```
+
++ Make sure that all components are running without errors.
+
++ After that, follow the steps in `Regenerate certificate files and add SANs` tab and migrate to your own certificate.
+
 </TabItem>
 </Tabs>
 

--- a/docs/02.deploying/01.production/04.internal/04.internal.md
+++ b/docs/02.deploying/01.production/04.internal/04.internal.md
@@ -5,9 +5,9 @@ taxonomy:
 slug: /deploying/production/internal
 ---
 
-:::note
-For versions prior to 5.4.2, after Mar. 2025, internal certificate has to be generated/replaced before using NeuVector.
-For versions of 5.4.2 and later, internal certificate has to be generated/replaced before using NeuVector.
+:::important
+NeuVector versions 5.4.2 and later must have users generate/replace internal certificates before using NeuVector.
+After March 2025, NeuVector versions prior to 5.4.2 must have users generate/replace internal certificates before using NeuVector.
 :::
 
 ### Internal Communication and Certificates

--- a/versioned_docs/version-5.2/02.deploying/01.production/04.internal/04.internal.md
+++ b/versioned_docs/version-5.2/02.deploying/01.production/04.internal/04.internal.md
@@ -5,8 +5,9 @@ taxonomy:
 slug: /deploying/production/internal
 ---
 
-:::note
-After Mar. 2025, internal certificate has to be generated/replaced before using NeuVector.
+:::important
+NeuVector versions 5.4.2 and later must have users generate/replace internal certificates before using NeuVector.
+After March 2025, NeuVector versions prior to 5.4.2 must have users generate/replace internal certificates before using NeuVector.
 :::
 
 ### Internal Communication and Certificates

--- a/versioned_docs/version-5.2/02.deploying/01.production/04.internal/04.internal.md
+++ b/versioned_docs/version-5.2/02.deploying/01.production/04.internal/04.internal.md
@@ -5,6 +5,10 @@ taxonomy:
 slug: /deploying/production/internal
 ---
 
+:::note
+After Mar. 2025, internal certificate has to be generated/replaced before using NeuVector.
+:::
+
 ### Internal Communication and Certificates
 
 NeuVector includes default self-signed certificates for encryption for the Manager (console/UI access), Controller (REST API, internal), Enforcer (internal), and Scanner (internal) communications.

--- a/versioned_docs/version-5.3/02.deploying/01.production/04.internal/04.internal.md
+++ b/versioned_docs/version-5.3/02.deploying/01.production/04.internal/04.internal.md
@@ -5,8 +5,9 @@ taxonomy:
 slug: /deploying/production/internal
 ---
 
-:::note
-After Mar. 2025, internal certificate has to be generated/replaced before using NeuVector.
+:::important
+NeuVector versions 5.4.2 and later must have users generate/replace internal certificates before using NeuVector.
+After March 2025, NeuVector versions prior to 5.4.2 must have users generate/replace internal certificates before using NeuVector.
 :::
 
 ### Internal Communication and Certificates

--- a/versioned_docs/version-5.3/02.deploying/01.production/04.internal/04.internal.md
+++ b/versioned_docs/version-5.3/02.deploying/01.production/04.internal/04.internal.md
@@ -5,6 +5,10 @@ taxonomy:
 slug: /deploying/production/internal
 ---
 
+:::note
+After Mar. 2025, internal certificate has to be generated/replaced before using NeuVector.
+:::
+
 ### Internal Communication and Certificates
 
 NeuVector includes default self-signed certificates for encryption for the Manager (console/UI access), Controller (REST API, internal), Enforcer (internal), and Scanner (internal) communications.

--- a/versioned_docs/version-5.4/02.deploying/01.production/04.internal/04.internal.md
+++ b/versioned_docs/version-5.4/02.deploying/01.production/04.internal/04.internal.md
@@ -5,6 +5,11 @@ taxonomy:
 slug: /deploying/production/internal
 ---
 
+:::note
+For versions prior to 5.4.2, after Mar. 2025, internal certificate has to be generated/replaced before using NeuVector.
+For versions of 5.4.2 and later, internal certificate has to be generated/replaced before using NeuVector.
+:::
+
 ### Internal Communication and Certificates
 
 NeuVector includes default self-signed certificates for encryption for the Manager (console/UI access), Controller (REST API, internal), Enforcer (internal), and Scanner (internal) communications.
@@ -244,6 +249,34 @@ kubectl rollout status ds neuvector-enforcer-pod
 ```
 
 + Make sure the console can be accessed and controllers are all online.
+</TabItem>
+<TabItem value="regenerate_cert_from_builtin" label="Regenerate certificate when built-in certificate is being used">
+If you didn't replace the internal certificate before and want to migrate to a new set of certificates, follow the steps below:
+
++ Check if you already have the internal certificate generated automatically.
+
+```bash
+kubectl get secret internal-cert -o yaml
+```
+
+If you see `tls.key`, `tls.crt` and `ca.crt` there, that means you've been using the automatically generated certificate and you can skip this section.
+
+If you can see the secret, but cannot find these secrets, consider enabling `internal.autoRotateCert` in the helm charts override. This option will generate and rotate your internal certificate automatically.
+
+If you don't use the automatically generated internal certificate and can't do so, follow the steps below:
+
++ Follow the steps in the `New certificate` tab to use a Kubernetes secret to manage the internal certificate. Instead of generating a new certificate, use the certificate, `old-ca.crt`, `old-tls.crt` and `old-tls.key`, retrieved below:
+
+```
+docker run -it --entrypoint=bash neuvector/scanner:3.654 -c "cat /etc/neuvector/certs/internal/ca.cert" > old-ca.crt
+docker run -it --entrypoint=bash neuvector/scanner:3.654 -c "cat /etc/neuvector/certs/internal/cert.pem" > old-tls.crt
+docker run -it --entrypoint=bash neuvector/scanner:3.654 -c "cat /etc/neuvector/certs/internal/cert.key" > old-tls.key
+```
+
++ Make sure that all components are running without errors.
+
++ After that, follow the steps in `Regenerate certificate files and add SANs` tab and migrate to your own certificate.
+
 </TabItem>
 </Tabs>
 

--- a/versioned_docs/version-5.4/02.deploying/01.production/04.internal/04.internal.md
+++ b/versioned_docs/version-5.4/02.deploying/01.production/04.internal/04.internal.md
@@ -5,9 +5,9 @@ taxonomy:
 slug: /deploying/production/internal
 ---
 
-:::note
-For versions prior to 5.4.2, after Mar. 2025, internal certificate has to be generated/replaced before using NeuVector.
-For versions of 5.4.2 and later, internal certificate has to be generated/replaced before using NeuVector.
+:::important
+NeuVector versions 5.4.2 and later must have users generate/replace internal certificates before using NeuVector.
+After March 2025, NeuVector versions prior to 5.4.2 must have users generate/replace internal certificates before using NeuVector.
 :::
 
 ### Internal Communication and Certificates


### PR DESCRIPTION
Update internal certificate related document. 

Note: This should only be merged after 5.4.2 is released. 