### PR TITLE
[NVSHAS-8911] Security Events Note

### DIFF
--- a/docs/07.reporting/01.reporting/01.reporting.md
+++ b/docs/07.reporting/01.reporting/01.reporting.md
@@ -99,6 +99,10 @@ Violations are connections that violate the whitelist Rules or match a blacklist
 
 In this view, you can review network, process, and file events and easily add a whitelist rule for false positives by clicking the Review Rule button. The Advanced Filter enables you to select the type of event to display.
 
+:::important
+When adding a whitelist rule, please be explicit in the network, process or file event addition (e.g. `("sshd", "/usr/sbin/sshd")`). Do not use the character `(*)` when adding a rule as it may add unexpected processes which could be flagged as process violations.
+:::
+
 ![AddRule](security_events_addrule.png)
 
 NeuVector also continuously monitors all containers for know attacks such as DNS, DDoS, HTTP-smuggling, tunneling etc. When an attack is detected it is logged here and blocked (if container/service is set to protect), and the packet is automatically captured. You can view the packet details, for example:

--- a/versioned_docs/version-5.2/07.reporting/01.reporting/01.reporting.md
+++ b/versioned_docs/version-5.2/07.reporting/01.reporting/01.reporting.md
@@ -99,6 +99,10 @@ Violations are connections that violate the whitelist Rules or match a blacklist
 
 In this view, you can review network, process, and file events and easily add a whitelist rule for false positives by clicking the Review Rule button. The Advanced Filter enables you to select the type of event to display.
 
+:::important
+When adding a whitelist rule, please be explicit in the network, process or file event addition (e.g. `("sshd", "/usr/sbin/sshd")`). Do not use the character `(*)` when adding a rule as it may add unexpected processes which could be flagged as process violations.
+:::
+
 ![AddRule](security_events_addrule.png)
 
 NeuVector also continuously monitors all containers for know attacks such as DNS, DDoS, HTTP-smuggling, tunneling etc. When an attack is detected it is logged here and blocked (if container/service is set to protect), and the packet is automatically captured. You can view the packet details, for example:

--- a/versioned_docs/version-5.3/07.reporting/01.reporting/01.reporting.md
+++ b/versioned_docs/version-5.3/07.reporting/01.reporting/01.reporting.md
@@ -99,6 +99,10 @@ Violations are connections that violate the whitelist Rules or match a blacklist
 
 In this view, you can review network, process, and file events and easily add a whitelist rule for false positives by clicking the Review Rule button. The Advanced Filter enables you to select the type of event to display.
 
+:::important
+When adding a whitelist rule, please be explicit in the network, process or file event addition (e.g. `("sshd", "/usr/sbin/sshd")`). Do not use the character `(*)` when adding a rule as it may add unexpected processes which could be flagged as process violations.
+:::
+
 ![AddRule](security_events_addrule.png)
 
 NeuVector also continuously monitors all containers for know attacks such as DNS, DDoS, HTTP-smuggling, tunneling etc. When an attack is detected it is logged here and blocked (if container/service is set to protect), and the packet is automatically captured. You can view the packet details, for example:

--- a/versioned_docs/version-5.4/07.reporting/01.reporting/01.reporting.md
+++ b/versioned_docs/version-5.4/07.reporting/01.reporting/01.reporting.md
@@ -99,6 +99,10 @@ Violations are connections that violate the whitelist Rules or match a blacklist
 
 In this view, you can review network, process, and file events and easily add a whitelist rule for false positives by clicking the Review Rule button. The Advanced Filter enables you to select the type of event to display.
 
+:::important
+When adding a whitelist rule, please be explicit in the network, process or file event addition (e.g. `("sshd", "/usr/sbin/sshd")`). Do not use the character `(*)` when adding a rule as it may add unexpected processes which could be flagged as process violations.
+:::
+
 ![AddRule](security_events_addrule.png)
 
 NeuVector also continuously monitors all containers for know attacks such as DNS, DDoS, HTTP-smuggling, tunneling etc. When an attack is detected it is logged here and blocked (if container/service is set to protect), and the packet is automatically captured. You can view the packet details, for example:


### PR DESCRIPTION
Adding note to "Security Events" section on not using the catch-all character `(*)` when adding a whitelist rule as unexpected processes could be flagged causing process violations. Tied to NVSHAS-8911.