### PR TITLE
[NVSHAS-8799, NVSHAS-6955, NVSHAS-7945] Updating Prime Compliance - 5.4

### DIFF
--- a/docs/06.scanning/01.scanning/01.scanning.md
+++ b/docs/06.scanning/01.scanning/01.scanning.md
@@ -52,11 +52,15 @@ NeuVector provides several ways to review vulnerability and compliance scan resu
 
 #### Security Risks Menu
 
+:::note
+The Community release of NeuVector 5.4.0 has removed the NIST regulation compliance. It is available in the [Prime release of NeuVector 5.4.0](https://documentation.suse.com/cloudnative/security/5.4/en/compliance.html#_customizing_compliance_templates_for_pci_gdpr_hipaa_nist_pciv4_and_disa_stig).
+:::
+
 These menu's combine the results from registry (image), node, and container vulnerability scans and compliance checks found in the Assets menu to enable end-to-end vulnerability management and reporting. The Compliance profile menu enables customization of the PCI, GDPR and other compliance checks for generating compliance reports.
 
 ![SecurityRisks](vulnerabilities_4_4.png)
 
-See the next section on [Vulnerability Management](/scanning/scanning/vulnerabilities) for how to manage vulnerabilities in this menu, and the [Compliance & CIS Benchmarks](/scanning/scanning/compliance) section for reporting on CIS Benchmarks and industry compliance such as PCI, GDPR, HIPAA, and NIST.
+See the next section on [Vulnerability Management](/scanning/scanning/vulnerabilities) for how to manage vulnerabilities in this menu, and the [Compliance & CIS Benchmarks](/scanning/scanning/compliance) section for reporting on CIS Benchmarks and industry compliance such as PCI, GDPR, HIPAA.
 
 #### Assets Menu
 

--- a/docs/06.scanning/01.scanning/02.compliance/02.compliance.md
+++ b/docs/06.scanning/01.scanning/02.compliance/02.compliance.md
@@ -34,9 +34,13 @@ The following screenshot shows an example of a secret found in an image scan.
 
 ![secrets](secret_compliance_4.png)
 
-##### Customizing Compliance Templates for PCI, GDPR, HIPAA, NIST and others
+##### Customizing Compliance Templates for PCI, GDPR, HIPAA and others
 
-The Compliance profile menu enables customization of the built-in templates for industry standards such as PCI and GDPR. These reports can be generated from the Security Risks -> Compliance menu by selecting one of the standards to filter, then exporting. The NIST profile is for [NIST SP 800-190](https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-190.pdf).
+:::note
+The Community release of NeuVector 5.4.0 has removed the NIST regulation compliance. It is available in the [Prime release of NeuVector 5.4.0](https://documentation.suse.com/cloudnative/security/5.4/en/compliance.html#_customizing_compliance_templates_for_pci_gdpr_hipaa_nist_pciv4_and_disa_stig).
+:::
+
+The Compliance profile menu enables customization of the built-in templates for industry standards such as PCI and GDPR. These reports can be generated from the Security Risks -> Compliance menu by selecting one of the standards to filter, then exporting.
 
 To customize any compliance profile, select the industry standard (e.g. PCI), then enable or disable specific checks for that standard. Think of these as compliance 'tags' that are applied to each check in order to generate a compliance report for that industry standard.
 

--- a/versioned_docs/version-5.4/06.scanning/01.scanning/01.scanning.md
+++ b/versioned_docs/version-5.4/06.scanning/01.scanning/01.scanning.md
@@ -52,11 +52,15 @@ NeuVector provides several ways to review vulnerability and compliance scan resu
 
 #### Security Risks Menu
 
+:::note
+The Community release of NeuVector 5.4.0 has removed the NIST regulation compliance. It is available in the [Prime release of NeuVector 5.4.0](https://documentation.suse.com/cloudnative/security/5.4/en/compliance.html#_customizing_compliance_templates_for_pci_gdpr_hipaa_nist_pciv4_and_disa_stig).
+:::
+
 These menu's combine the results from registry (image), node, and container vulnerability scans and compliance checks found in the Assets menu to enable end-to-end vulnerability management and reporting. The Compliance profile menu enables customization of the PCI, GDPR and other compliance checks for generating compliance reports.
 
 ![SecurityRisks](vulnerabilities_4_4.png)
 
-See the next section on [Vulnerability Management](/scanning/scanning/vulnerabilities) for how to manage vulnerabilities in this menu, and the [Compliance & CIS Benchmarks](/scanning/scanning/compliance) section for reporting on CIS Benchmarks and industry compliance such as PCI, GDPR, HIPAA, and NIST.
+See the next section on [Vulnerability Management](/scanning/scanning/vulnerabilities) for how to manage vulnerabilities in this menu, and the [Compliance & CIS Benchmarks](/scanning/scanning/compliance) section for reporting on CIS Benchmarks and industry compliance such as PCI, GDPR, HIPAA.
 
 #### Assets Menu
 

--- a/versioned_docs/version-5.4/06.scanning/01.scanning/02.compliance/02.compliance.md
+++ b/versioned_docs/version-5.4/06.scanning/01.scanning/02.compliance/02.compliance.md
@@ -34,9 +34,13 @@ The following screenshot shows an example of a secret found in an image scan.
 
 ![secrets](secret_compliance_4.png)
 
-##### Customizing Compliance Templates for PCI, GDPR, HIPAA, NIST and others
+##### Customizing Compliance Templates for PCI, GDPR, HIPAA and others
 
-The Compliance profile menu enables customization of the built-in templates for industry standards such as PCI and GDPR. These reports can be generated from the Security Risks -> Compliance menu by selecting one of the standards to filter, then exporting. The NIST profile is for [NIST SP 800-190](https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-190.pdf).
+:::note
+The Community release of NeuVector 5.4.0 has removed the NIST regulation compliance. It is available in the [Prime release of NeuVector 5.4.0](https://documentation.suse.com/cloudnative/security/5.4/en/compliance.html#_customizing_compliance_templates_for_pci_gdpr_hipaa_nist_pciv4_and_disa_stig).
+:::
+
+The Compliance profile menu enables customization of the built-in templates for industry standards such as PCI and GDPR. These reports can be generated from the Security Risks -> Compliance menu by selecting one of the standards to filter, then exporting.
 
 To customize any compliance profile, select the industry standard (e.g. PCI), then enable or disable specific checks for that standard. Think of these as compliance 'tags' that are applied to each check in order to generate a compliance report for that industry standard.
 


### PR DESCRIPTION
Updating the community documentation wrt to compliance templates available. Removing NIST as was removed in NV v5.4.0 release. Tied to NVSHAS-8799, NVSHAS-6955, and NVSHAS-7945.

Updated in product-docs: https://github.com/rancher/neuvector-product-docs/pull/21