### PR TITLE
[5.4.3] Feature Update - name_referral

### DIFF
--- a/docs/05.policy/13.usingcrd/13.usingcrd.md
+++ b/docs/05.policy/13.usingcrd/13.usingcrd.md
@@ -5,7 +5,7 @@ taxonomy:
 slug: /policy/usingcrd
 ---
 
-### NeuVector CRD for Policy As Code
+## NeuVector CRD for Policy As Code
 
 NeuVector custom resource definitions (CRDs) can be used by various teams to automatically define security policies in the NeuVector container security platform. Developers, DevOps, DevSecOps, and Security teams can collaborate to automate security policies for new or updated applications deployed to production. CRDs can also be used to enforce global security policies across multiple Kubernetes clusters.
 
@@ -27,9 +27,26 @@ CRD's bring many benefits, including:
 + Version and track the security policies the same as application deployment manifests.
 + Define the allowed behavior of any application including network, file and process behavior.
 
-#### Supported Resource Types
+## Supported Resource Types
 
-NeuVector supports the NvSecurityRule, NvClusterSecurityRule, and NvAdmissionControlSecurityRule custom resource definitions.
+NeuVector supports the following custom resource definitions:
+
++ NvAdmissionControlSecurityRule
++ NvClusterSecurityRule
++ NvGroupDefinition
++ NvSecurityRule
+
+### NvGroupDefinition
+
+The NvGroupDefinition custom resource represents a group's definition (`criteria/comment`). The security-related settings still remain in the NvSecurityRule/NvClusterSecurityRule custom resources. All NvGroupDefinition custom resources are under the `neuvector` namespace.
+
+#### Schema Attribute: `name_referral`
+
+NeuVector v5.4.3 adds the attribute `name_referral` (boolean) as a setting in the group selector(`target.selector`, `ingress.items[].selector`, `egress.items[].selector`) in the NvSecurityRule/NvClusterSecurityRule CRD schema.
+
+If the `name_referral` attribute is set to `true`, the `criteria/comment` fields of the group selector in NvSecurityRule/NvClusterSecurityRule are ignored by NeuVector. This means that NeuVector will try to determine the group's `criteria/comment` by referral. This introduces "group referral" in NvSecurityRule/NvClusterSecurityRule CRDs to assist with modifications when editing groups. If unset then users will need to update groups in each defined place in the respective yaml files if modifications are needed.
+
+### NvClusterSecurityRule and NvSecurityRule
 
 The difference between the NvSecurityRule and NvClusterSecurityRule is the boundary set by the definition of the scope. The NvSecurityRule resource is scoped at the namespace level, whereas the NvClusterSecurityRule is scoped at the cluster level. The resource types can be configured in a yaml file and can be created during deployment, as shown in the deployment instructions and examples for NeuVector.
 
@@ -37,12 +54,13 @@ The significance of the NvSecurityRule resource type with a scope of namespace l
 
 For the NvClusterSecurityRule custom resource definition, this has a cluster level scope, and therefore, does not enforce any namespace boundary on a defined target. However, the user-context that is used for importing the CRD-yaml file must have the necessary permissions to access or reside in the same namespace as the one configured in the CRD-yaml file, or the import will be rejected.
 
-<strong>Enabling CRD Support</strong>
+#### Enabling CRD Support
+
 As described in the [Kubernetes](../../02.deploying/02.kubernetes/02.kubernetes.md#deploy-neuvector) and [OpenShift](../../02.deploying/04.openshift/04.openshift.md#deploy-on-openshift) deployment sections (Deploying NeuVector),  the appropriate clusterroles and clusterrole bindings for custom resources and NvSecurityRules should be added first.
 
 Then NvSecurityRule and NvClusterSecurityRule should be created using the sample yaml in those sections. NeuVector CRDs can now be deployed.
 
-### Generating a Sample NeuVector CRD
+## Generating a Sample NeuVector CRD
 
 The simplest way to see how the yaml file format looks for a NeuVector CRD is to export it from the NeuVector Console. After you have tested your application while NeuVector is in Discover mode learning the network, file, and process behavior, you can export the learned policy.
 
@@ -56,7 +74,10 @@ Then select the Groups that you wish to export, such as the three in the demo na
 In addition to the selected group(s), all 'linked' groups will also be exported. A linked group is any other group that a selected group will connect to or from as allowed by a network rule.
 :::
 
-Sample Exported CRD
+Sample Exported CRD:
+
+<details>
+<summary>Sample Exported CRD</summary>
 
 ```yaml
 apiVersion: v1
@@ -270,6 +291,8 @@ kind: List
 metadata: null
 ```
 
+</details>
+
 For example:
 
 + This is a namespaced CRD, of NvSecurityRule
@@ -279,7 +302,7 @@ For example:
 + node-pod.demo is allowed to egress to google.com using SSL
 + Group names such as nv.node-pod.demo are referenced but not defined in the CRD, so are expected to already exist when deployed. See below for defining Groups.
 
-#### Sample NeuVector CRD - NvAdmissionControlSecurityRule
+### Sample NeuVector CRD - NvAdmissionControlSecurityRule
 
 Another method to generate a CRD manifest is from the **Policy > Admission Control** view by clicking the **More Operations** drop-down list and selecting **Export**. Below is a sample NvAdmissionControlSecurityRule CRD manifest:
 
@@ -315,7 +338,7 @@ You can refer to the [complete schema for the CRD](https://raw.githubusercontent
 
 Once the modifications are done, you can apply the manifest to your Kubernetes cluster.
 
-### Policy Mode Configuration and Group Definition
+## Policy Mode Configuration and Group Definition
 
 Policy mode configuration and Group definition is supported within the CRD configuration yaml file.  With policymode configured in the yaml configuration file, importing such file will set the target group to this value for the CRD import.  
 
@@ -327,7 +350,7 @@ The imported target policy mode is not allowed to be modified from the NeuVector
 The CRD import behavior ignores the PolicyMode of any 'linked' group, leaving the Policy mode unchanged if the linked group already exists. If the linked group does not exist it will be automatically created and set to the default New Services Mode in Settings -> Configuration.
 :::
 
-#### Policy Mode Configuration Requirements
+### Policy Mode Configuration Requirements
 
 + Mode only applies to the configured Target group
 + The target group configuration must have the format nv.SERVICE_NAME.DOMAIN. 
@@ -354,7 +377,7 @@ Policy Mode Configuration Yaml file Example
             op: "="
 ```
 
-### CRD Policy Rules Syntax and Semantics
+## CRD Policy Rules Syntax and Semantics
 
 <strong>Group Name</strong>
 + Avoid using names which start with fed., nv.ip., host:, or workload: which are reserved for federated groups or ip based services. 
@@ -448,7 +471,7 @@ Policy Mode Configuration Yaml file Example
     - recursive: true/false
 
 
-### RBAC Support with CRDs
+## RBAC Support with CRDs
 
 Utilizing Kubernetes existing RBAC model, NeuVector extends the CRD (Custom Resource Definition) to support RBAC by utilizing Kubernetes’s Rolebinding in association with the configured Namespace in the NeuVector  configured CRD rules when using the NvSecurityRule resource-type. This configured Namespace is then used to enforce the configured Target, which must reside in this namespace configured in the NeuVector security policy. When rolebinding a defined clusterrole, this can be used to bind to a Kubernetes User or Group. The two clusterrole resources types that NeuVector supports are NvSecurityRule and NvClusterSecurityRule.
 
@@ -577,7 +600,7 @@ Next, we can switch the user-context to user2 with a broader scope privilege, cl
 Therefore, using user2 to import either yaml file (nvsecurity.yaml
 or nvclustersecurity.yaml) will be allowed, since this user’s Clusterrolebinding is not restricted to either resource NvSecurityRules (Namespace-Scope) or NvClusterSecurityRules (Cluster-Scope).
 
-### Expressing Network Rules (Ingress, Egress objects) in CRDs
+## Expressing Network Rules (Ingress, Egress objects) in CRDs
 
 Network rules expressed in CRDs have an Ingress and/or Egress object, which define the allowed incoming and outgoing connections (protocols, ports etc) to/from the workload (Group). Each network rule in NeuVector must have a unique name in a CRD. Note that in the console, network rules only have a unique ID number. 
 
@@ -612,7 +635,7 @@ Custom, user created groups are not allowed to have the 'nv.' prefix. Only disco
         name: nv.node-pod.demo
 ```
 
-### Customized Configurations for Deployed Applications
+## Customized Configurations for Deployed Applications
 
 With the use of a customized CRD yaml file, this enables you to customize network security rules, file access rules, and process security rules, all bundled into a single configuration file.  There are multiple benefits to allow these customizations.  
 
@@ -674,7 +697,7 @@ spec:
 
 The above snippet is configured to enforce ssh access from the target group container nv.alpine.ns1 to the egress group nv.redhat.ns2.  In addition, the enforcement of file access and the process rules are defined and applied to the configured target container nv.alpine.ns1.  With this bundled configuration, we have allowed the defined network, file, and process security rules to act upon the configured target group.
 
-### Policy Groups and Rules Migration Support
+## Policy Groups and Rules Migration Support
 
 NeuVector supports the exporting of certain NeuVector group types from a Kubernetes cluster in a yaml file and importing into another Kubernetes cluster by utilizing native kubectl commands.  
 
@@ -783,7 +806,7 @@ The CRD import behavior ignores the PolicyMode of any 'linked' group, leaving th
 + If the imported group exists in the destination system with different criteria or values, the import will be rejected.
 + If the imported group exists in the destination system with identical configurations, we will reuse the existing group with different type.
 
-### CRD Samples for Global Rules
+## CRD Samples for Global Rules
 
 The sample CRD below has two parts:
 
@@ -869,7 +892,7 @@ metadata: null
 
 To allow, or whitelist a process such as a monitoring process to run, just add a process rule with action: allow for the process name, and add the path.  The path must be specified for allow rules but is optional for deny rules.
 
-### Updating CRD Rules and Adding to Existing Groups
+## Updating CRD Rules and Adding to Existing Groups
 
 Updating the CRD generated rules in NeuVector is as simple as updating the appropriate yaml file and applying the update:
 
@@ -877,6 +900,6 @@ Updating the CRD generated rules in NeuVector is as simple as updating the appro
 kubectl apply -f <crdrule.yaml>
 ```
 
-#### Dynamic criteria support for NvClusterSecurityRule  
+### Dynamic criteria support for NvClusterSecurityRule  
 
 Multiple CRDs which change the criteria for existing custom group(s) are supported. This feature also allows the user to apply multiple CRDs at once, where the NeuVector behavior is to accept and queue the CRD so the immediate response to the user is always success.  During processing, any errors are reported into the console Notifications -> Events. 

--- a/versioned_docs/version-5.4/05.policy/13.usingcrd/13.usingcrd.md
+++ b/versioned_docs/version-5.4/05.policy/13.usingcrd/13.usingcrd.md
@@ -5,7 +5,7 @@ taxonomy:
 slug: /policy/usingcrd
 ---
 
-### NeuVector CRD for Policy As Code
+## NeuVector CRD for Policy As Code
 
 NeuVector custom resource definitions (CRDs) can be used by various teams to automatically define security policies in the NeuVector container security platform. Developers, DevOps, DevSecOps, and Security teams can collaborate to automate security policies for new or updated applications deployed to production. CRDs can also be used to enforce global security policies across multiple Kubernetes clusters.
 
@@ -27,9 +27,26 @@ CRD's bring many benefits, including:
 + Version and track the security policies the same as application deployment manifests.
 + Define the allowed behavior of any application including network, file and process behavior.
 
-#### Supported Resource Types
+## Supported Resource Types
 
-NeuVector supports the NvSecurityRule, NvClusterSecurityRule, and NvAdmissionControlSecurityRule custom resource definitions.
+NeuVector supports the following custom resource definitions:
+
++ NvAdmissionControlSecurityRule
++ NvClusterSecurityRule
++ NvGroupDefinition
++ NvSecurityRule
+
+### NvGroupDefinition
+
+The NvGroupDefinition custom resource represents a group's definition (`criteria/comment`). The security-related settings still remain in the NvSecurityRule/NvClusterSecurityRule custom resources. All NvGroupDefinition custom resources are under the `neuvector` namespace.
+
+#### Schema Attribute: `name_referral`
+
+NeuVector v5.4.3 adds the attribute `name_referral` (boolean) as a setting in the group selector(`target.selector`, `ingress.items[].selector`, `egress.items[].selector`) in the NvSecurityRule/NvClusterSecurityRule CRD schema.
+
+If the `name_referral` attribute is set to `true`, the `criteria/comment` fields of the group selector in NvSecurityRule/NvClusterSecurityRule are ignored by NeuVector. This means that NeuVector will try to determine the group's `criteria/comment` by referral. This introduces "group referral" in NvSecurityRule/NvClusterSecurityRule CRDs to assist with modifications when editing groups. If unset then users will need to update groups in each defined place in the respective yaml files if modifications are needed.
+
+### NvClusterSecurityRule and NvSecurityRule
 
 The difference between the NvSecurityRule and NvClusterSecurityRule is the boundary set by the definition of the scope. The NvSecurityRule resource is scoped at the namespace level, whereas the NvClusterSecurityRule is scoped at the cluster level. The resource types can be configured in a yaml file and can be created during deployment, as shown in the deployment instructions and examples for NeuVector.
 
@@ -37,12 +54,13 @@ The significance of the NvSecurityRule resource type with a scope of namespace l
 
 For the NvClusterSecurityRule custom resource definition, this has a cluster level scope, and therefore, does not enforce any namespace boundary on a defined target. However, the user-context that is used for importing the CRD-yaml file must have the necessary permissions to access or reside in the same namespace as the one configured in the CRD-yaml file, or the import will be rejected.
 
-<strong>Enabling CRD Support</strong>
+#### Enabling CRD Support
+
 As described in the [Kubernetes](../../02.deploying/02.kubernetes/02.kubernetes.md#deploy-neuvector) and [OpenShift](../../02.deploying/04.openshift/04.openshift.md#deploy-on-openshift) deployment sections (Deploying NeuVector),  the appropriate clusterroles and clusterrole bindings for custom resources and NvSecurityRules should be added first.
 
 Then NvSecurityRule and NvClusterSecurityRule should be created using the sample yaml in those sections. NeuVector CRDs can now be deployed.
 
-### Generating a Sample NeuVector CRD
+## Generating a Sample NeuVector CRD
 
 The simplest way to see how the yaml file format looks for a NeuVector CRD is to export it from the NeuVector Console. After you have tested your application while NeuVector is in Discover mode learning the network, file, and process behavior, you can export the learned policy.
 
@@ -56,7 +74,10 @@ Then select the Groups that you wish to export, such as the three in the demo na
 In addition to the selected group(s), all 'linked' groups will also be exported. A linked group is any other group that a selected group will connect to or from as allowed by a network rule.
 :::
 
-Sample Exported CRD
+Sample Exported CRD:
+
+<details>
+<summary>Sample Exported CRD</summary>
 
 ```yaml
 apiVersion: v1
@@ -270,6 +291,8 @@ kind: List
 metadata: null
 ```
 
+</details>
+
 For example:
 
 + This is a namespaced CRD, of NvSecurityRule
@@ -279,7 +302,7 @@ For example:
 + node-pod.demo is allowed to egress to google.com using SSL
 + Group names such as nv.node-pod.demo are referenced but not defined in the CRD, so are expected to already exist when deployed. See below for defining Groups.
 
-#### Sample NeuVector CRD - NvAdmissionControlSecurityRule
+### Sample NeuVector CRD - NvAdmissionControlSecurityRule
 
 Another method to generate a CRD manifest is from the **Policy > Admission Control** view by clicking the **More Operations** drop-down list and selecting **Export**. Below is a sample NvAdmissionControlSecurityRule CRD manifest:
 
@@ -315,7 +338,7 @@ You can refer to the [complete schema for the CRD](https://raw.githubusercontent
 
 Once the modifications are done, you can apply the manifest to your Kubernetes cluster.
 
-### Policy Mode Configuration and Group Definition
+## Policy Mode Configuration and Group Definition
 
 Policy mode configuration and Group definition is supported within the CRD configuration yaml file.  With policymode configured in the yaml configuration file, importing such file will set the target group to this value for the CRD import.  
 
@@ -327,7 +350,7 @@ The imported target policy mode is not allowed to be modified from the NeuVector
 The CRD import behavior ignores the PolicyMode of any 'linked' group, leaving the Policy mode unchanged if the linked group already exists. If the linked group does not exist it will be automatically created and set to the default New Services Mode in Settings -> Configuration.
 :::
 
-#### Policy Mode Configuration Requirements
+### Policy Mode Configuration Requirements
 
 + Mode only applies to the configured Target group
 + The target group configuration must have the format nv.SERVICE_NAME.DOMAIN. 
@@ -354,7 +377,7 @@ Policy Mode Configuration Yaml file Example
             op: "="
 ```
 
-### CRD Policy Rules Syntax and Semantics
+## CRD Policy Rules Syntax and Semantics
 
 <strong>Group Name</strong>
 + Avoid using names which start with fed., nv.ip., host:, or workload: which are reserved for federated groups or ip based services. 
@@ -448,7 +471,7 @@ Policy Mode Configuration Yaml file Example
     - recursive: true/false
 
 
-### RBAC Support with CRDs
+## RBAC Support with CRDs
 
 Utilizing Kubernetes existing RBAC model, NeuVector extends the CRD (Custom Resource Definition) to support RBAC by utilizing Kubernetes’s Rolebinding in association with the configured Namespace in the NeuVector  configured CRD rules when using the NvSecurityRule resource-type. This configured Namespace is then used to enforce the configured Target, which must reside in this namespace configured in the NeuVector security policy. When rolebinding a defined clusterrole, this can be used to bind to a Kubernetes User or Group. The two clusterrole resources types that NeuVector supports are NvSecurityRule and NvClusterSecurityRule.
 
@@ -577,7 +600,7 @@ Next, we can switch the user-context to user2 with a broader scope privilege, cl
 Therefore, using user2 to import either yaml file (nvsecurity.yaml
 or nvclustersecurity.yaml) will be allowed, since this user’s Clusterrolebinding is not restricted to either resource NvSecurityRules (Namespace-Scope) or NvClusterSecurityRules (Cluster-Scope).
 
-### Expressing Network Rules (Ingress, Egress objects) in CRDs
+## Expressing Network Rules (Ingress, Egress objects) in CRDs
 
 Network rules expressed in CRDs have an Ingress and/or Egress object, which define the allowed incoming and outgoing connections (protocols, ports etc) to/from the workload (Group). Each network rule in NeuVector must have a unique name in a CRD. Note that in the console, network rules only have a unique ID number. 
 
@@ -612,7 +635,7 @@ Custom, user created groups are not allowed to have the 'nv.' prefix. Only disco
         name: nv.node-pod.demo
 ```
 
-### Customized Configurations for Deployed Applications
+## Customized Configurations for Deployed Applications
 
 With the use of a customized CRD yaml file, this enables you to customize network security rules, file access rules, and process security rules, all bundled into a single configuration file.  There are multiple benefits to allow these customizations.  
 
@@ -674,7 +697,7 @@ spec:
 
 The above snippet is configured to enforce ssh access from the target group container nv.alpine.ns1 to the egress group nv.redhat.ns2.  In addition, the enforcement of file access and the process rules are defined and applied to the configured target container nv.alpine.ns1.  With this bundled configuration, we have allowed the defined network, file, and process security rules to act upon the configured target group.
 
-### Policy Groups and Rules Migration Support
+## Policy Groups and Rules Migration Support
 
 NeuVector supports the exporting of certain NeuVector group types from a Kubernetes cluster in a yaml file and importing into another Kubernetes cluster by utilizing native kubectl commands.  
 
@@ -783,7 +806,7 @@ The CRD import behavior ignores the PolicyMode of any 'linked' group, leaving th
 + If the imported group exists in the destination system with different criteria or values, the import will be rejected.
 + If the imported group exists in the destination system with identical configurations, we will reuse the existing group with different type.
 
-### CRD Samples for Global Rules
+## CRD Samples for Global Rules
 
 The sample CRD below has two parts:
 
@@ -869,7 +892,7 @@ metadata: null
 
 To allow, or whitelist a process such as a monitoring process to run, just add a process rule with action: allow for the process name, and add the path.  The path must be specified for allow rules but is optional for deny rules.
 
-### Updating CRD Rules and Adding to Existing Groups
+## Updating CRD Rules and Adding to Existing Groups
 
 Updating the CRD generated rules in NeuVector is as simple as updating the appropriate yaml file and applying the update:
 
@@ -877,6 +900,6 @@ Updating the CRD generated rules in NeuVector is as simple as updating the appro
 kubectl apply -f <crdrule.yaml>
 ```
 
-#### Dynamic criteria support for NvClusterSecurityRule  
+### Dynamic criteria support for NvClusterSecurityRule  
 
 Multiple CRDs which change the criteria for existing custom group(s) are supported. This feature also allows the user to apply multiple CRDs at once, where the NeuVector behavior is to accept and queue the CRD so the immediate response to the user is always success.  During processing, any errors are reported into the console Notifications -> Events. 


### PR DESCRIPTION
Updating the CRD page with new v5.4.3 feature `name_referral` and NvGroupDefinition CRD. Tied to [NVSHAS-9871] and [NVSHAS-4717].
The main content additions are under the headers "### NvGroupDefinition" and "#### Schema Attribute: `name_referral`". The page headers had to be adjusted as well as the right-side navigation was not displaying items that were too deeply nested.