### PR TITLE
Update NV 5.4 Release Note - DISA STIG

### DIFF
--- a/docs/14.releasenotes/01.5x/01.5x.md
+++ b/docs/14.releasenotes/01.5x/01.5x.md
@@ -250,7 +250,7 @@ Please note the stand-alone scanner will not be affected by these changes.
 + **NVSHAS-8845**: Create APIKEY with role FedReader and FedAdmin.
 + **NVSHAS-9306**: Admission Control configuration assessment shows rule ID responsible for allowed or denied deployments.
 + **NVSHAS-9078**: Support for image signing for OCI images.
-+ **NVSHAS-7945**: (_Available for Rancher users by default or available when deployed from a Rancher Chart._) Support DISA STIG benchmark for Kubernetes.
++ **NVSHAS-7945**: (*Available when deployed from a Rancher Chart.*) Support DISA STIG benchmark for Kubernetes.
 + **NVSHAS-8234**: Admission Control Logic allowing images that should be denied.
 
 ##### Bug Fixes:

--- a/docs/14.releasenotes/01.5x/01.5x.md
+++ b/docs/14.releasenotes/01.5x/01.5x.md
@@ -250,7 +250,7 @@ Please note the stand-alone scanner will not be affected by these changes.
 + **NVSHAS-8845**: Create APIKEY with role FedReader and FedAdmin.
 + **NVSHAS-9306**: Admission Control configuration assessment shows rule ID responsible for allowed or denied deployments.
 + **NVSHAS-9078**: Support for image signing for OCI images.
-+ **NVSHAS-7945**: (**Available for Prime only users**) Support DISA STIG benchmark for Kubernetes.
++ **NVSHAS-7945**: (_Available for Rancher users by default or available when deployed from a Rancher Chart._) Support DISA STIG benchmark for Kubernetes.
 + **NVSHAS-8234**: Admission Control Logic allowing images that should be denied.
 
 ##### Bug Fixes:

--- a/docs/14.releasenotes/01.5x/01.5x.md
+++ b/docs/14.releasenotes/01.5x/01.5x.md
@@ -250,7 +250,7 @@ Please note the stand-alone scanner will not be affected by these changes.
 + **NVSHAS-8845**: Create APIKEY with role FedReader and FedAdmin.
 + **NVSHAS-9306**: Admission Control configuration assessment shows rule ID responsible for allowed or denied deployments.
 + **NVSHAS-9078**: Support for image signing for OCI images.
-+ **NVSHAS-7945**: Support DISA STIG benchmark for Kubernetes.
++ **NVSHAS-7945**: (**Available for Prime only users**) Support DISA STIG benchmark for Kubernetes.
 + **NVSHAS-8234**: Admission Control Logic allowing images that should be denied.
 
 ##### Bug Fixes:

--- a/versioned_docs/version-5.4/14.releasenotes/01.5x/01.5x.md
+++ b/versioned_docs/version-5.4/14.releasenotes/01.5x/01.5x.md
@@ -250,7 +250,7 @@ Please note the stand-alone scanner will not be affected by these changes.
 + **NVSHAS-8845**: Create APIKEY with role FedReader and FedAdmin.
 + **NVSHAS-9306**: Admission Control configuration assessment shows rule ID responsible for allowed or denied deployments.
 + **NVSHAS-9078**: Support for image signing for OCI images.
-+ **NVSHAS-7945**: **Available for Prime only users** Support DISA STIG benchmark for Kubernetes.
++ **NVSHAS-7945**: (_Available for Rancher users by default or available when deployed from a Rancher Chart._) Support DISA STIG benchmark for Kubernetes.
 + **NVSHAS-8234**: Admission Control Logic allowing images that should be denied.
 
 ##### Bug Fixes:

--- a/versioned_docs/version-5.4/14.releasenotes/01.5x/01.5x.md
+++ b/versioned_docs/version-5.4/14.releasenotes/01.5x/01.5x.md
@@ -250,7 +250,7 @@ Please note the stand-alone scanner will not be affected by these changes.
 + **NVSHAS-8845**: Create APIKEY with role FedReader and FedAdmin.
 + **NVSHAS-9306**: Admission Control configuration assessment shows rule ID responsible for allowed or denied deployments.
 + **NVSHAS-9078**: Support for image signing for OCI images.
-+ **NVSHAS-7945**: Support DISA STIG benchmark for Kubernetes.
++ **NVSHAS-7945**: **Available for Prime only users** Support DISA STIG benchmark for Kubernetes.
 + **NVSHAS-8234**: Admission Control Logic allowing images that should be denied.
 
 ##### Bug Fixes:

--- a/versioned_docs/version-5.4/14.releasenotes/01.5x/01.5x.md
+++ b/versioned_docs/version-5.4/14.releasenotes/01.5x/01.5x.md
@@ -250,7 +250,7 @@ Please note the stand-alone scanner will not be affected by these changes.
 + **NVSHAS-8845**: Create APIKEY with role FedReader and FedAdmin.
 + **NVSHAS-9306**: Admission Control configuration assessment shows rule ID responsible for allowed or denied deployments.
 + **NVSHAS-9078**: Support for image signing for OCI images.
-+ **NVSHAS-7945**: (_Available for Rancher users by default or available when deployed from a Rancher Chart._) Support DISA STIG benchmark for Kubernetes.
++ **NVSHAS-7945**: (*Available when deployed from a Rancher Chart.*) Support DISA STIG benchmark for Kubernetes.
 + **NVSHAS-8234**: Admission Control Logic allowing images that should be denied.
 
 ##### Bug Fixes:


### PR DESCRIPTION
Adding information to 5.4 release note on DISA STIG Prime availability to clarify for users. In the 5.4 usage documentation, DISA STIG is stated to be for Prime users only. @selvamt94 could you please verify and thank you in advance!