### PR TITLE
Update the link to the file access rules

### DIFF
--- a/docs/07.reporting/01.reporting/01.reporting.md
+++ b/docs/07.reporting/01.reporting/01.reporting.md
@@ -125,7 +125,7 @@ Create an advanced filter for viewing or exporting events by selecting each gene
 + Process. Process whitelist violations or suspicious processes detected such as NMAP, SSH etc.
 + Package. A package has been updated or installed in the container therefore this generated a security event.
 + Tunnel. A tunnel violation has been detected. Tunneling, typically dns tunneling is used to steal data. This detection is done by seeing a tunnel process start and correlating it with a network activity with dns protocol. See sample event below.  Description of iodine tunnel https://github.com/yarrick/iodine
-+ File. File access violation. Either a monitored sensitive file/directory has been accessed (see list of default monitoring, or a custom file monitor rule has been triggered. https://docs.neuvector.com/policy/filerules
++ File. File access violation. Either a monitored sensitive file/directory has been accessed (see list of default monitoring, or a custom file monitor rule has been triggered. https://open-docs.neuvector.com/policy/filerules
 + Privilege. A privilege escalation has been detected in container or host. Privilege escalations can be done in many ways and are not 100% detectable so this is a difficult condition to test.
 
 #### Risk Reports

--- a/docs/07.reporting/01.reporting/01.reporting.md
+++ b/docs/07.reporting/01.reporting/01.reporting.md
@@ -125,7 +125,7 @@ Create an advanced filter for viewing or exporting events by selecting each gene
 + Process. Process whitelist violations or suspicious processes detected such as NMAP, SSH etc.
 + Package. A package has been updated or installed in the container therefore this generated a security event.
 + Tunnel. A tunnel violation has been detected. Tunneling, typically dns tunneling is used to steal data. This detection is done by seeing a tunnel process start and correlating it with a network activity with dns protocol. See sample event below.  Description of iodine tunnel https://github.com/yarrick/iodine
-+ File. File access violation. Either a monitored sensitive file/directory has been accessed (see list of default monitoring, or a custom file monitor rule has been triggered. https://open-docs.neuvector.com/policy/filerules
++ File. File access violation. Either a monitored sensitive file/directory has been accessed (see list of default monitoring, or a custom file monitor rule has been triggered. Refer to the [File Access Rules](../../05.policy/07.filerules/07.filerules.md) page for more information.
 + Privilege. A privilege escalation has been detected in container or host. Privilege escalations can be done in many ways and are not 100% detectable so this is a difficult condition to test.
 
 #### Risk Reports

--- a/versioned_docs/version-5.2/07.reporting/01.reporting/01.reporting.md
+++ b/versioned_docs/version-5.2/07.reporting/01.reporting/01.reporting.md
@@ -125,7 +125,7 @@ Create an advanced filter for viewing or exporting events by selecting each gene
 + Process. Process whitelist violations or suspicious processes detected such as NMAP, SSH etc.
 + Package. A package has been updated or installed in the container therefore this generated a security event.
 + Tunnel. A tunnel violation has been detected. Tunneling, typically dns tunneling is used to steal data. This detection is done by seeing a tunnel process start and correlating it with a network activity with dns protocol. See sample event below.  Description of iodine tunnel https://github.com/yarrick/iodine
-+ File. File access violation. Either a monitored sensitive file/directory has been accessed (see list of default monitoring, or a custom file monitor rule has been triggered. https://open-docs.neuvector.com/policy/filerules
++ File. File access violation. Either a monitored sensitive file/directory has been accessed (see list of default monitoring) or a custom file monitor rule has been triggered. Refer to the [File Access Rules](../../05.policy/07.filerules/07.filerules.md) page for more information.
 + Privilege. A privilege escalation has been detected in container or host. Privilege escalations can be done in many ways and are not 100% detectable so this is a difficult condition to test.
 
 #### Risk Reports

--- a/versioned_docs/version-5.2/07.reporting/01.reporting/01.reporting.md
+++ b/versioned_docs/version-5.2/07.reporting/01.reporting/01.reporting.md
@@ -125,7 +125,7 @@ Create an advanced filter for viewing or exporting events by selecting each gene
 + Process. Process whitelist violations or suspicious processes detected such as NMAP, SSH etc.
 + Package. A package has been updated or installed in the container therefore this generated a security event.
 + Tunnel. A tunnel violation has been detected. Tunneling, typically dns tunneling is used to steal data. This detection is done by seeing a tunnel process start and correlating it with a network activity with dns protocol. See sample event below.  Description of iodine tunnel https://github.com/yarrick/iodine
-+ File. File access violation. Either a monitored sensitive file/directory has been accessed (see list of default monitoring, or a custom file monitor rule has been triggered. https://docs.neuvector.com/policy/filerules
++ File. File access violation. Either a monitored sensitive file/directory has been accessed (see list of default monitoring, or a custom file monitor rule has been triggered. https://open-docs.neuvector.com/policy/filerules
 + Privilege. A privilege escalation has been detected in container or host. Privilege escalations can be done in many ways and are not 100% detectable so this is a difficult condition to test.
 
 #### Risk Reports

--- a/versioned_docs/version-5.3/07.reporting/01.reporting/01.reporting.md
+++ b/versioned_docs/version-5.3/07.reporting/01.reporting/01.reporting.md
@@ -125,7 +125,7 @@ Create an advanced filter for viewing or exporting events by selecting each gene
 + Process. Process whitelist violations or suspicious processes detected such as NMAP, SSH etc.
 + Package. A package has been updated or installed in the container therefore this generated a security event.
 + Tunnel. A tunnel violation has been detected. Tunneling, typically dns tunneling is used to steal data. This detection is done by seeing a tunnel process start and correlating it with a network activity with dns protocol. See sample event below.  Description of iodine tunnel https://github.com/yarrick/iodine
-+ File. File access violation. Either a monitored sensitive file/directory has been accessed (see list of default monitoring, or a custom file monitor rule has been triggered. https://open-docs.neuvector.com/policy/filerules
++ File. File access violation. Either a monitored sensitive file/directory has been accessed (see list of default monitoring) or a custom file monitor rule has been triggered. Refer to the [File Access Rules](../../05.policy/07.filerules/07.filerules.md) page for more information.
 + Privilege. A privilege escalation has been detected in container or host. Privilege escalations can be done in many ways and are not 100% detectable so this is a difficult condition to test.
 
 #### Risk Reports

--- a/versioned_docs/version-5.3/07.reporting/01.reporting/01.reporting.md
+++ b/versioned_docs/version-5.3/07.reporting/01.reporting/01.reporting.md
@@ -125,7 +125,7 @@ Create an advanced filter for viewing or exporting events by selecting each gene
 + Process. Process whitelist violations or suspicious processes detected such as NMAP, SSH etc.
 + Package. A package has been updated or installed in the container therefore this generated a security event.
 + Tunnel. A tunnel violation has been detected. Tunneling, typically dns tunneling is used to steal data. This detection is done by seeing a tunnel process start and correlating it with a network activity with dns protocol. See sample event below.  Description of iodine tunnel https://github.com/yarrick/iodine
-+ File. File access violation. Either a monitored sensitive file/directory has been accessed (see list of default monitoring, or a custom file monitor rule has been triggered. https://docs.neuvector.com/policy/filerules
++ File. File access violation. Either a monitored sensitive file/directory has been accessed (see list of default monitoring, or a custom file monitor rule has been triggered. https://open-docs.neuvector.com/policy/filerules
 + Privilege. A privilege escalation has been detected in container or host. Privilege escalations can be done in many ways and are not 100% detectable so this is a difficult condition to test.
 
 #### Risk Reports

--- a/versioned_docs/version-5.4/07.reporting/01.reporting/01.reporting.md
+++ b/versioned_docs/version-5.4/07.reporting/01.reporting/01.reporting.md
@@ -125,7 +125,7 @@ Create an advanced filter for viewing or exporting events by selecting each gene
 + Process. Process whitelist violations or suspicious processes detected such as NMAP, SSH etc.
 + Package. A package has been updated or installed in the container therefore this generated a security event.
 + Tunnel. A tunnel violation has been detected. Tunneling, typically dns tunneling is used to steal data. This detection is done by seeing a tunnel process start and correlating it with a network activity with dns protocol. See sample event below.  Description of iodine tunnel https://github.com/yarrick/iodine
-+ File. File access violation. Either a monitored sensitive file/directory has been accessed (see list of default monitoring, or a custom file monitor rule has been triggered. https://open-docs.neuvector.com/policy/filerules
++ File. File access violation. Either a monitored sensitive file/directory has been accessed (see list of default monitoring) or a custom file monitor rule has been triggered. Refer to the [File Access Rules](../../05.policy/07.filerules/07.filerules.md) page for more information.
 + Privilege. A privilege escalation has been detected in container or host. Privilege escalations can be done in many ways and are not 100% detectable so this is a difficult condition to test.
 
 #### Risk Reports

--- a/versioned_docs/version-5.4/07.reporting/01.reporting/01.reporting.md
+++ b/versioned_docs/version-5.4/07.reporting/01.reporting/01.reporting.md
@@ -125,7 +125,7 @@ Create an advanced filter for viewing or exporting events by selecting each gene
 + Process. Process whitelist violations or suspicious processes detected such as NMAP, SSH etc.
 + Package. A package has been updated or installed in the container therefore this generated a security event.
 + Tunnel. A tunnel violation has been detected. Tunneling, typically dns tunneling is used to steal data. This detection is done by seeing a tunnel process start and correlating it with a network activity with dns protocol. See sample event below.  Description of iodine tunnel https://github.com/yarrick/iodine
-+ File. File access violation. Either a monitored sensitive file/directory has been accessed (see list of default monitoring, or a custom file monitor rule has been triggered. https://docs.neuvector.com/policy/filerules
++ File. File access violation. Either a monitored sensitive file/directory has been accessed (see list of default monitoring, or a custom file monitor rule has been triggered. https://open-docs.neuvector.com/policy/filerules
 + Privilege. A privilege escalation has been detected in container or host. Privilege escalations can be done in many ways and are not 100% detectable so this is a difficult condition to test.
 
 #### Risk Reports


### PR DESCRIPTION
The link for the file access rules for security policies still link to the previous `docs` subdomain which is inactive.

Updated in the old 5.x versioned documentation as well.