### PR TITLE
Adding Note - PCIv4 Source

### DIFF
--- a/docs/06.scanning/01.scanning/02.compliance/02.compliance.md
+++ b/docs/06.scanning/01.scanning/02.compliance/02.compliance.md
@@ -37,7 +37,10 @@ The following screenshot shows an example of a secret found in an image scan.
 ##### Customizing Compliance Templates for PCI, GDPR, HIPAA and others
 
 :::note
-The Community release of NeuVector 5.4.0 has removed the NIST regulation compliance. It is available in the [Prime release of NeuVector 5.4.0](https://documentation.suse.com/cloudnative/security/5.4/en/compliance.html#_customizing_compliance_templates_for_pci_gdpr_hipaa_nist_pciv4_and_disa_stig).
+
++ The Community release of NeuVector v5.4.0 has removed the NIST regulation compliance. It is available in the [Prime release of NeuVector v5.4.0](https://documentation.suse.com/cloudnative/security/5.4/en/compliance.html#_customizing_compliance_templates_for_pci_gdpr_hipaa_nist_pciv4_and_disa_stig).
++ Available from release v5.4.1, NeuVector references the PCI DSS v4.0 guidelines from the official [PCI Security Standards blog](https://blog.pcisecuritystandards.org/pci-dss-v4-0-resource-hub).
+
 :::
 
 The Compliance profile menu enables customization of the built-in templates for industry standards such as PCI and GDPR. These reports can be generated from the Security Risks -> Compliance menu by selecting one of the standards to filter, then exporting.

--- a/versioned_docs/version-5.4/06.scanning/01.scanning/02.compliance/02.compliance.md
+++ b/versioned_docs/version-5.4/06.scanning/01.scanning/02.compliance/02.compliance.md
@@ -37,7 +37,10 @@ The following screenshot shows an example of a secret found in an image scan.
 ##### Customizing Compliance Templates for PCI, GDPR, HIPAA and others
 
 :::note
-The Community release of NeuVector 5.4.0 has removed the NIST regulation compliance. It is available in the [Prime release of NeuVector 5.4.0](https://documentation.suse.com/cloudnative/security/5.4/en/compliance.html#_customizing_compliance_templates_for_pci_gdpr_hipaa_nist_pciv4_and_disa_stig).
+
++ The Community release of NeuVector v5.4.0 has removed the NIST regulation compliance. It is available in the [Prime release of NeuVector v5.4.0](https://documentation.suse.com/cloudnative/security/5.4/en/compliance.html#_customizing_compliance_templates_for_pci_gdpr_hipaa_nist_pciv4_and_disa_stig).
++ Available from release v5.4.1, NeuVector references the PCI DSS v4.0 guidelines from the official [PCI Security Standards blog](https://blog.pcisecuritystandards.org/pci-dss-v4-0-resource-hub).
+
 :::
 
 The Compliance profile menu enables customization of the built-in templates for industry standards such as PCI and GDPR. These reports can be generated from the Security Risks -> Compliance menu by selecting one of the standards to filter, then exporting.


### PR DESCRIPTION
Adding note regarding PCIv4 guideline source. Fixes https://github.com/neuvector/docs/issues/160.