### PR TITLE
Adding workaround for large host environments

### DIFF
--- a/docs/01.basics/02.requirements/02.requirements.md
+++ b/docs/01.basics/02.requirements/02.requirements.md
@@ -149,3 +149,21 @@ The table below shows the average latency of 2-10% benchmarked using the Redis b
 
 
 The benchmark above shows average TPS of Protect mode versus Monitor mode, and the latency added for Protect mode for several tests in the benchmark. The main way to lower the actual latency (microseconds) in Protect mode is to run on a system with a faster CPU. You can find more details on this open source Redis benchmark tool at https://redis.io/topics/benchmarks.
+
+### Adding Scaling Constraints for Large Workload Environments
+
+During NeuVector installation, if your host operating system has a large amount of workloads then the NeuVector Enforcer pods can fail to spin up when trying to open the large volume of files due to the pods host monitoring. This can also cause RKE2-server failures because of the large amounts of open files.
+
+As a workaround for large workload environments, you need to create a file such as `example-fs-max.conf` in the location `/etc/sysctl.d/` and add scaling constraints with the following configuration:
+
+```shell
+fs.inotify.max_user_instances=8192
+fs.inotify.max_user_watches=524288
+fs.filemax=5000
+```
+
+Then ensure the configuration is applied with a restart via the following command:
+
+```shell
+systemctl restart systemd-sysctl
+```

--- a/versioned_docs/version-5.4/01.basics/02.requirements/02.requirements.md
+++ b/versioned_docs/version-5.4/01.basics/02.requirements/02.requirements.md
@@ -149,3 +149,21 @@ The table below shows the average latency of 2-10% benchmarked using the Redis b
 
 
 The benchmark above shows average TPS of Protect mode versus Monitor mode, and the latency added for Protect mode for several tests in the benchmark. The main way to lower the actual latency (microseconds) in Protect mode is to run on a system with a faster CPU. You can find more details on this open source Redis benchmark tool at https://redis.io/topics/benchmarks.
+
+### Adding Scaling Constraints for Large Workload Environments
+
+During NeuVector installation, if your host operating system has a large amount of workloads then the NeuVector Enforcer pods can fail to spin up when trying to open the large volume of files due to the pods host monitoring. This can also cause RKE2-server failures because of the large amounts of open files.
+
+As a workaround for large workload environments, you need to create a file such as `example-fs-max.conf` in the location `/etc/sysctl.d/` and add scaling constraints with the following configuration:
+
+```shell
+fs.inotify.max_user_instances=8192
+fs.inotify.max_user_watches=524288
+fs.filemax=5000
+```
+
+Then ensure the configuration is applied with a restart via the following command:
+
+```shell
+systemctl restart systemd-sysctl
+```


### PR DESCRIPTION
Adding workaround for large host environments, tied to SURE-10116.
Product PR: https://github.com/rancher/neuvector-product-docs/pull/32