### PR TITLE
[NVSHAS-9961] Updating 'Resetting Admin Password' Section

### DIFF
--- a/docs/02.deploying/10.remove/10.remove.md
+++ b/docs/02.deploying/10.remove/10.remove.md
@@ -29,21 +29,28 @@ In addition to deleting as discussed above and redeploying NeuVector, the follow
 
 The admin password is the key to administering the NeuVector deployment and viewing the cluster network activities. It is important to change the password upon install and keep it safely guarded. If you have `kubectl` access to the cluster, you can reset the admin password to the default using the following steps.
 
-Bash access is disabled by default to harden NeuVector pod security. If resetting the admin password, you need to first disable `nv_protect` which is tied to the Enforcer where the Controller is running in order to access Bash.
+Consul CLI access is disabled by default to harden NeuVector pod security. If resetting the admin password, you need to first disable `nv_protect` which is tied to the Enforcer where the Controller is running in order to access the consul CLI. The below `override.yaml` configuration can be applied by an admin user to disable `nv_protect` and allows for running your consul CLI directly in the Controller pods.
 
-1. Execute the command below through the NeuVector CLI to disable `nv_protect`, then you will be able to `kubectl exec` into the specified Controller.
+:::important
 
-    ```shell
-    set enforcer <enforcer_id> nv_protect disable true
-    ```
+If using continuous delivery in your deployment, you can add a temporary admin user by enabling the attribute `always_reload: true` noted in the example `userinitcfg.yaml` in the [ConfigMap](/deploying/production/configmap/#complete-sample-neuvector-configmap-initcfgyaml) and then following the steps below.
 
-2. `kubectl exec` into one of the Controllers.
+:::
+
+```yaml
+enforcer:
+  env:
+    - name: ENFORCER_SKIP_NV_PROTECT
+      value: "1"
+```
+
+1. `kubectl exec` into one of the Controllers.
 
     ```shell
     kubectl exec -it <controller> -n neuvector -- sh
     ```
 
-3. Check that the admin entry exists and save the output JSON somewhere for safe keeping.
+2. Check that the admin entry exists and save the output JSON somewhere for safe keeping.
 
     ```shell
     consul kv get object/config/user/admin
@@ -55,13 +62,13 @@ Bash access is disabled by default to harden NeuVector pod security. If resettin
 
     :::
 
-4. Take the output from the above `consul kv get` command and replace the `password_hash` string with the below string.
+3. Take the output from the above `consul kv get` command and replace the `password_hash` string with the below string.
 
     ```shell
     c7ad44cbad762a5da0a452f9e854fdc1e0e7a52a38015f23f3eab1d80b931dd472634dfac71cd34ebc35d16ab7fb8a90c81f975113d6c7538dc69dd8de9077ec
     ```
 
-5. Reset the admin account password back to the default.
+4. Reset the admin account password back to the default.
 
     :::warning
 
@@ -85,4 +92,4 @@ Bash access is disabled by default to harden NeuVector pod security. If resettin
     Success! Data written to: object/config/user/admin
     ```
 
-6. Login with admin/admin and the change password.
+5. Login with admin/admin and change the password.

--- a/docs/02.deploying/10.remove/10.remove.md
+++ b/docs/02.deploying/10.remove/10.remove.md
@@ -27,46 +27,62 @@ In addition to deleting as discussed above and redeploying NeuVector, the follow
 
 ### Resetting the Admin Password
 
-The admin password is the key to administering the NeuVector deployment and view the cluster network activities.  It is important to change the password upon install and keep it safely guarded.  Sometimes, the password is guarded too well and become loss or the administrator leaves the company.  If you have kubectl access to the cluster, you can reset the admin password to the default using the following steps.
+The admin password is the key to administering the NeuVector deployment and viewing the cluster network activities. It is important to change the password upon install and keep it safely guarded. If you have `kubectl` access to the cluster, you can reset the admin password to the default using the following steps.
 
-Exec into one of the controllers.
+Bash access is disabled by default to harden NeuVector pod security. If resetting the admin password, you need to first disable `nv_protect` which is tied to the Enforcer where the Controller is running in order to access Bash.
 
-```shell
-kubectl exec -it <controller> -n neuvector -- sh
-```
+1. Execute the command below through the NeuVector CLI to disable `nv_protect`, then you will be able to `kubectl exec` into the specified Controller.
 
-Check that the admin entry exists and save the output json somewhere for safe keeping. 
+    ```shell
+    set enforcer <enforcer_id> nv_protect disable true
+    ```
 
-```shell
-consul kv get object/config/user/admin
-```
+2. `kubectl exec` into one of the Controllers.
 
-:::important
-Before continuing, make sure you saved the command `consul kv get` output into a file.
-:::
+    ```shell
+    kubectl exec -it <controller> -n neuvector -- sh
+    ```
 
-Take the output from the above consul kv get command and replace the password_hash string with below string.
+3. Check that the admin entry exists and save the output JSON somewhere for safe keeping.
 
-```shell
-c7ad44cbad762a5da0a452f9e854fdc1e0e7a52a38015f23f3eab1d80b931dd472634dfac71cd34ebc35d16ab7fb8a90c81f975113d6c7538dc69dd8de9077ec
-```
+    ```shell
+    consul kv get object/config/user/admin
+    ```
 
-Reset the admin account password back to the default. (REPLACE \<UPDATED_consul_kv_get_output_with_new_password_hash\> BEFORE EXECUTION!!!)
+    :::important
 
-```shell
-consul kv put object/config/user/admin '<UPDATED_consul_kv_get_output_with_new_password_hash>'
-```
+    Before continuing, make sure you've saved the output of command `consul kv get` into a file.
 
-EXAMPLE BELOW: (DO NOT EXECUTE WITHOUT REPLACING WITH OUTPUT)
+    :::
 
-```shell
-consul kv put object/config/user/admin '{"fullname":"admin","username":"admin","password_hash":"c7ad44cbad762a5da0a452f9e854fdc1e0e7a52a38015f23f3eab1d80b931dd472634dfac71cd34ebc35d16ab7fb8a90c81f975113d6c7538dc69dd8de9077ec","pwd_reset_time":"2022-03-24T20:50:15.341074451Z","pwd_hash_history":null,"domain":"","server":"","email":"","role":"admin","role_oride":false,"timeout":300,"locale":"en","role_domains":{},"last_login_at":"2022-03-24T20:49:32.577877044Z","login_count":1,"failed_login_count":0,"block_login_since":"0001-01-01T00:00:00Z"}'
-```
+4. Take the output from the above `consul kv get` command and replace the `password_hash` string with the below string.
 
-Response:
+    ```shell
+    c7ad44cbad762a5da0a452f9e854fdc1e0e7a52a38015f23f3eab1d80b931dd472634dfac71cd34ebc35d16ab7fb8a90c81f975113d6c7538dc69dd8de9077ec
+    ```
 
-```shell
-Success! Data written to: object/config/user/admin
-```
+5. Reset the admin account password back to the default.
 
-Login with admin/admin and change password.
+    :::warning
+
+    Replace \<UPDATED_consul_kv_get_output_with_new_password_hash\> before executing this steps command.
+
+    :::
+
+    ```shell
+    consul kv put object/config/user/admin '<UPDATED_consul_kv_get_output_with_new_password_hash>'
+    ```
+
+    Example below: **(Do not execute without replacing with intended `<UPDATED_consul_kv_get_output_with_new_password_hash>`)**
+
+    ```shell
+    consul kv put object/config/user/admin '{"fullname":"admin","username":"admin","password_hash":"c7ad44cbad762a5da0a452f9e854fdc1e0e7a52a38015f23f3eab1d80b931dd472634dfac71cd34ebc35d16ab7fb8a90c81f975113d6c7538dc69dd8de9077ec","pwd_reset_time":"2022-03-24T20:50:15.341074451Z","pwd_hash_history":null,"domain":"","server":"","email":"","role":"admin","role_oride":false,"timeout":300,"locale":"en","role_domains":{},"last_login_at":"2022-03-24T20:49:32.577877044Z","login_count":1,"failed_login_count":0,"block_login_since":"0001-01-01T00:00:00Z"}'
+    ```
+
+    Response:
+
+    ```shell
+    Success! Data written to: object/config/user/admin
+    ```
+
+6. Login with admin/admin and the change password.

--- a/versioned_docs/version-5.4/02.deploying/10.remove/10.remove.md
+++ b/versioned_docs/version-5.4/02.deploying/10.remove/10.remove.md
@@ -29,21 +29,28 @@ In addition to deleting as discussed above and redeploying NeuVector, the follow
 
 The admin password is the key to administering the NeuVector deployment and viewing the cluster network activities. It is important to change the password upon install and keep it safely guarded. If you have `kubectl` access to the cluster, you can reset the admin password to the default using the following steps.
 
-Starting in v5.4.3, Bash access is disabled by default to harden NeuVector pod security. If resetting the admin password, you need to first disable `nv_protect` which is tied to the Enforcer where the Controller is running in order to access Bash.
+Starting in v5.4.3, consul CLI access is disabled by default to harden NeuVector pod security. If resetting the admin password, you need to first disable `nv_protect` which is tied to the Enforcer where the Controller is running in order to access the consul CLI. The below `override.yaml` configuration can be applied by an admin user to disable `nv_protect` and allows for running your consul CLI directly in the Controller pods.
 
-1. Execute the command below through the NeuVector CLI to disable `nv_protect`, then you will be able to `kubectl exec` into the specified Controller.
+:::important
 
-    ```shell
-    set enforcer <enforcer_id> nv_protect disable true
-    ```
+If using continuous delivery in your deployment, you can add a temporary admin user by enabling the attribute `always_reload: true` noted in the example `userinitcfg.yaml` in the [ConfigMap](/deploying/production/configmap/#complete-sample-neuvector-configmap-initcfgyaml) and then following the steps below.
 
-2. `kubectl exec` into one of the Controllers.
+:::
+
+```yaml
+enforcer:
+  env:
+    - name: ENFORCER_SKIP_NV_PROTECT
+      value: "1"
+```
+
+1. `kubectl exec` into one of the Controllers.
 
     ```shell
     kubectl exec -it <controller> -n neuvector -- sh
     ```
 
-3. Check that the admin entry exists and save the output JSON somewhere for safe keeping.
+2. Check that the admin entry exists and save the output JSON somewhere for safe keeping.
 
     ```shell
     consul kv get object/config/user/admin
@@ -55,13 +62,13 @@ Starting in v5.4.3, Bash access is disabled by default to harden NeuVector pod s
 
     :::
 
-4. Take the output from the above `consul kv get` command and replace the `password_hash` string with the below string.
+3. Take the output from the above `consul kv get` command and replace the `password_hash` string with the below string.
 
     ```shell
     c7ad44cbad762a5da0a452f9e854fdc1e0e7a52a38015f23f3eab1d80b931dd472634dfac71cd34ebc35d16ab7fb8a90c81f975113d6c7538dc69dd8de9077ec
     ```
 
-5. Reset the admin account password back to the default.
+4. Reset the admin account password back to the default.
 
     :::warning
 
@@ -85,4 +92,4 @@ Starting in v5.4.3, Bash access is disabled by default to harden NeuVector pod s
     Success! Data written to: object/config/user/admin
     ```
 
-6. Login with admin/admin and change the password.
+5. Login with admin/admin and change the password.

--- a/versioned_docs/version-5.4/02.deploying/10.remove/10.remove.md
+++ b/versioned_docs/version-5.4/02.deploying/10.remove/10.remove.md
@@ -27,42 +27,62 @@ In addition to deleting as discussed above and redeploying NeuVector, the follow
 
 ### Resetting the Admin Password
 
-The admin password is the key to administering the NeuVector deployment and view the cluster network activities.  It is important to change the password upon install and keep it safely guarded.  Sometimes, the password is guarded too well and become loss or the administrator leaves the company.  If you have kubectl access to the cluster, you can reset the admin password to the default using the following steps.
+The admin password is the key to administering the NeuVector deployment and viewing the cluster network activities. It is important to change the password upon install and keep it safely guarded. If you have `kubectl` access to the cluster, you can reset the admin password to the default using the following steps.
 
-Exec into one of the controllers.
+Starting in v5.4.3, Bash access is disabled by default to harden NeuVector pod security. If resetting the admin password, you need to first disable `nv_protect` which is tied to the Enforcer where the Controller is running in order to access Bash.
 
-```shell
-kubectl exec -it <controller> -n neuvector -- sh
-```
+1. Execute the command below through the NeuVector CLI to disable `nv_protect`, then you will be able to `kubectl exec` into the specified Controller.
 
-Check that the admin entry exists and save the output json somewhere for safe keeping. 
+    ```shell
+    set enforcer <enforcer_id> nv_protect disable true
+    ```
 
-```shell
-consul kv get object/config/user/admin
-```
+2. `kubectl exec` into one of the Controllers.
 
-Take the output from the above consul kv get command and replace the password_hash string with below string.
+    ```shell
+    kubectl exec -it <controller> -n neuvector -- sh
+    ```
 
-```shell
-c7ad44cbad762a5da0a452f9e854fdc1e0e7a52a38015f23f3eab1d80b931dd472634dfac71cd34ebc35d16ab7fb8a90c81f975113d6c7538dc69dd8de9077ec
-```
+3. Check that the admin entry exists and save the output JSON somewhere for safe keeping.
 
-Reset the admin account password back to the default. (REPLACE \<UPDATED_consul_kv_get_output_with_new_password_hash\> BEFORE EXECUTION!!!)
+    ```shell
+    consul kv get object/config/user/admin
+    ```
 
-```shell
-consul kv put object/config/user/admin '<UPDATED_consul_kv_get_output_with_new_password_hash>'
-```
+    :::important
 
-EXAMPLE BELOW: (DO NOT EXECUTE WITHOUT REPLACING WITH OUTPUT)
+    Before continuing, make sure you've saved the output of command `consul kv get` into a file.
 
-```shell
-consul kv put object/config/user/admin '{"fullname":"admin","username":"admin","password_hash":"c7ad44cbad762a5da0a452f9e854fdc1e0e7a52a38015f23f3eab1d80b931dd472634dfac71cd34ebc35d16ab7fb8a90c81f975113d6c7538dc69dd8de9077ec","pwd_reset_time":"2022-03-24T20:50:15.341074451Z","pwd_hash_history":null,"domain":"","server":"","email":"","role":"admin","role_oride":false,"timeout":300,"locale":"en","role_domains":{},"last_login_at":"2022-03-24T20:49:32.577877044Z","login_count":1,"failed_login_count":0,"block_login_since":"0001-01-01T00:00:00Z"}'
-```
+    :::
 
-Response:
+4. Take the output from the above `consul kv get` command and replace the `password_hash` string with the below string.
 
-```shell
-Success! Data written to: object/config/user/admin
-```
+    ```shell
+    c7ad44cbad762a5da0a452f9e854fdc1e0e7a52a38015f23f3eab1d80b931dd472634dfac71cd34ebc35d16ab7fb8a90c81f975113d6c7538dc69dd8de9077ec
+    ```
 
-Login with admin/admin and change password.
+5. Reset the admin account password back to the default.
+
+    :::warning
+
+    Replace \<UPDATED_consul_kv_get_output_with_new_password_hash\> before executing this steps command.
+
+    :::
+
+    ```shell
+    consul kv put object/config/user/admin '<UPDATED_consul_kv_get_output_with_new_password_hash>'
+    ```
+
+    Example below: **(Do not execute without replacing with intended `<UPDATED_consul_kv_get_output_with_new_password_hash>`)**
+
+    ```shell
+    consul kv put object/config/user/admin '{"fullname":"admin","username":"admin","password_hash":"c7ad44cbad762a5da0a452f9e854fdc1e0e7a52a38015f23f3eab1d80b931dd472634dfac71cd34ebc35d16ab7fb8a90c81f975113d6c7538dc69dd8de9077ec","pwd_reset_time":"2022-03-24T20:50:15.341074451Z","pwd_hash_history":null,"domain":"","server":"","email":"","role":"admin","role_oride":false,"timeout":300,"locale":"en","role_domains":{},"last_login_at":"2022-03-24T20:49:32.577877044Z","login_count":1,"failed_login_count":0,"block_login_since":"0001-01-01T00:00:00Z"}'
+    ```
+
+    Response:
+
+    ```shell
+    Success! Data written to: object/config/user/admin
+    ```
+
+6. Login with admin/admin and change the password.


### PR DESCRIPTION
Updating 'Resetting Admin Password' section. With v5.4.3 pod security hardening disabling Bash access by default an extra step was needed to disable this protection and allow access for resetting purposes. Tied to NVSHAS-9961.