### PR TITLE
Fix airgap deploy commands

### DIFF
--- a/versioned_docs/version-5.4/02.deploying/09.airgap/09.airgap.md
+++ b/versioned_docs/version-5.4/02.deploying/09.airgap/09.airgap.md
@@ -37,13 +37,13 @@ export vNeuVectorHelm=2.8.3
 
 # fetch the images
 helm repo add neuvector https://neuvector.github.io/neuvector-helm
-for image in $(helm template neuvector/core --version=${vNeuVector} | grep 'image:' | awk -F'"' '{print $2}' | sort -u); do
+for image in $(helm template neuvector/core --version=${vNeuVectorHelm} | grep 'image:' | awk -F'"' '{print $2}' | sort -u); do
     hauler store add image "$image"
 done
 
 # fetch the images (for supported customers)
 helm repo add neuvector https://neuvector.github.io/neuvector-helm
-for image in $(helm template neuvector/core --version=${vNeuVector} | grep 'image:' | awk -F'"' '{print $2}' | sort -u); do
+for image in $(helm template neuvector/core --version=${vNeuVectorHelm} | grep 'image:' | awk -F'"' '{print $2}' | sort -u); do
     hauler store add --registry <registry-url> image "$image"
 done
 
@@ -134,7 +134,7 @@ Once we are on our airgapped environment, use `hauler` to load the haul (tarball
 
 ```bash
 # load the haul
-hauler store load neuvector.tar.zst
+hauler store load -f neuvector.tar.zst
 
 # verify everything has been loaded
 root@hauler-neuvector-airgap hauler % hauler store info


### PR DESCRIPTION
fix shell & hauler flags. in hauler v1.2.x, they updated store copy usage.