### PR TITLE
5.4.6 Release Note/CVE

### DIFF
--- a/docs/14.releasenotes/01.5x/01.5x.md
+++ b/docs/14.releasenotes/01.5x/01.5x.md
@@ -13,7 +13,7 @@ To receive email notifications of new releases, please subscribe to this SUSE ma
 
 #### 5.4.6 August 2025
 
-##### New Features:
+##### New Features
 
 * **NVSHAS-6733**: Export response rules as CRD.
 * **NVSHAS-9899**: NeuVector Process Profile Alerts for Java Services contain sensitive data.
@@ -30,7 +30,7 @@ To receive email notifications of new releases, please subscribe to this SUSE ma
 * **NVSHAS-9985**:	NeuVector (Fed Master) creates a problem for all requests coming from outside.
 * **NVSHAS-9981**:	Security Event is triggered whenever a new "Process Profile Rule" is added or changed in a group.
 
-##### Security Advisories:
+##### Security Advisories
 
 * [Admin account has insecure default password](https://github.com/neuvector/neuvector/security/advisories/GHSA-8pxw-9c75-6w56)
 * [Insecure password management vulnerable to rainbow attacks](https://github.com/neuvector/neuvector/security/advisories/GHSA-8ff6-pc43-jwv3)
@@ -40,11 +40,11 @@ See the [Security Advisory and CVEs](/security_advisories/security_advisories/cv
 
 #### 5.4.5 July 2025
 
-##### New Features:
+##### New Features
 
 * **NVSHAS-9776**: Add etcd toleration in helm chart.
 
-##### Bug Fixes:
+##### Bug Fixes
 
 * **NVSHAS-9507**: OCI container not getting scanned.
 * **NVSHAS-9787**: Remove unnecessary manager log.
@@ -85,7 +85,7 @@ See the [Security Advisory and CVEs](/security_advisories/security_advisories/cv
 
 #### 5.4.4 May 2025
 
-##### New Features:
+##### New Features
 
 * **NVSHAS-9915**: Show scan results from the Harbor scanner module in the NeuVector UI.
 * **NVSHAS-9904**: Expose `imagePullPolicy` to `values.yaml` for each component.
@@ -95,7 +95,7 @@ See the [Security Advisory and CVEs](/security_advisories/security_advisories/cv
 * **NVSHAS-8160**: [Controller] Adjust some items for Security Risk Score calculation.
 * **NVSHAS-4673**: Suggestion to add message before exporting groups.
 
-##### Bug Fixes:
+##### Bug Fixes
 
 * **NVSHAS-9931**: Add a warning if there are inconsistent versions of NeuVector products in multi-cluster.
 * **NVSHAS-9925**: `/v1/scan/asset/images` API on the Registry Page fails.
@@ -114,7 +114,7 @@ See the [Security Advisory and CVEs](/security_advisories/security_advisories/cv
 
 #### 5.4.3 March 2025
 
-##### New Features:
+##### New Features
 
 * **NVSHAS-9793**: Allow Fed Global roles in LDAP/userinitcfg when deploying NeuVector through the ConfigMap and Secret.
 * **NVSHAS-9764**: [RFE] Add support for Azure for "Remote Repository Configuration".
@@ -127,7 +127,7 @@ See the [Security Advisory and CVEs](/security_advisories/security_advisories/cv
 * **NVSHAS-7997**: Scanner connector for ghcr.io.
 * **NVSHAS-7982**: Assign WAF sensors from Federation Master.
 
-##### Bug Fixes:
+##### Bug Fixes
 
 * **NVSHAS-9849**: Enforcers not registering with controllers.
 * **NVSHAS-9847**: Wildcard filters not working for Docker registry.
@@ -154,7 +154,7 @@ See the [Security Advisory and CVEs](/security_advisories/security_advisories/cv
 
 #### 5.4.2 January 2025
 
-##### New Features:
+##### New Features
 
 * **NVSHAS-9726**: The monitor now passes proxy URL.
 * **NVSHAS-9719**: Announces the retirement of built-in certificates.
@@ -164,7 +164,7 @@ See the [Security Advisory and CVEs](/security_advisories/security_advisories/cv
 * **NVSHAS-9590**: Ability to choose which vulnerability score for all assets.
 * **NVSHAS-7555**: Include "Auto Refresh" option under Security Events.
 
-##### Bug Fixes:
+##### Bug Fixes
 
 * **NVSHAS-9662**: Inconsistent Role/RoleBinding logic in Helm chart 2.8.2.
 * **NVSHAS-9652**: Observed difference in syslog format in splunk.
@@ -317,7 +317,7 @@ Please note the stand-alone scanner will not be affected by these changes.
   + Cloud billing data archiving.
   + Namespace boundary enforcement.
 
-##### New Features:
+##### New Features
 
 + **NVSHAS-9012**: Displaying Rancher SSO users on NV UI that have the same user name.
 + **NVSHAS-8939**: Provide an option on NV UI so that Rancher SSO session users can drop the current JWT token (i.e. logout).
@@ -354,7 +354,7 @@ Please note the stand-alone scanner will not be affected by these changes.
 + **NVSHAS-7945**: (*Available when deployed from a Rancher Chart.*) Support DISA STIG benchmark for Kubernetes.
 + **NVSHAS-8234**: Admission Control Logic allowing images that should be denied.
 
-##### Bug Fixes:
+##### Bug Fixes
 
 + **NVSHAS-9005**: TypeError in registries: Cannot read properties of undefined (reading 'total_records').
 + **NVSHAS-9085**: Assets View PDF report shows 0% vulnerability even with present vulnerabilities.

--- a/docs/16.security_advisories/01.security_advisories/cve.md
+++ b/docs/16.security_advisories/01.security_advisories/cve.md
@@ -4,7 +4,7 @@ NeuVector is committed to informing the community of security issues. Below is a
 
 ## CVE List
 
-| ID | Description | Date | Resolution |
+| ID | Description | Date | Release |
 | :---- | :---- | :---- | :---- |
 | [CVE-2025-8077](https://github.com/neuvector/neuvector/security/advisories/GHSA-8pxw-9c75-6w56) | For NeuVector deployment on the Kubernetes-based environment, the bootstrap password of the default admin user will be generated randomly and stored in a Kubernetes secret. The default admin will need to get the bootstrap password from the Kubernetes secret first and will be asked to change password after the first UI login is successful. | 25 Aug 2025 | [NeuVector v5.4.6](https://github.com/neuvector/neuvector/releases/tag/v5.4.6) |
 | [CVE-2025-53884](https://github.com/neuvector/neuvector/security/advisories/GHSA-8ff6-pc43-jwv3) | NeuVector uses a cryptographically secure salt with the PBKDF2 algorithm instead of a simple hash to protect user passwords.For rolling upgrades from earlier versions, NeuVector recalculates and stores the new password hash only after each user’s next successful login. | 25 Aug 2025 | [NeuVector v5.4.6](https://github.com/neuvector/neuvector/releases/tag/v5.4.6) |

--- a/versioned_docs/version-5.4/14.releasenotes/01.5x/01.5x.md
+++ b/versioned_docs/version-5.4/14.releasenotes/01.5x/01.5x.md
@@ -13,7 +13,7 @@ To receive email notifications of new releases, please subscribe to this SUSE ma
 
 #### 5.4.6 August 2025
 
-##### New Features:
+##### New Features
 
 * **NVSHAS-6733**: Export response rules as CRD.
 * **NVSHAS-9899**: NeuVector Process Profile Alerts for Java Services contain sensitive data.
@@ -30,7 +30,7 @@ To receive email notifications of new releases, please subscribe to this SUSE ma
 * **NVSHAS-9985**:	NeuVector (Fed Master) creates a problem for all requests coming from outside.
 * **NVSHAS-9981**:	Security Event is triggered whenever a new "Process Profile Rule" is added or changed in a group.
 
-##### Security Advisories:
+##### Security Advisories
 
 * [Admin account has insecure default password](https://github.com/neuvector/neuvector/security/advisories/GHSA-8pxw-9c75-6w56)
 * [Insecure password management vulnerable to rainbow attacks](https://github.com/neuvector/neuvector/security/advisories/GHSA-8ff6-pc43-jwv3)
@@ -40,11 +40,11 @@ See the [Security Advisory and CVEs](/security_advisories/security_advisories/cv
 
 #### 5.4.5 July 2025
 
-##### New Features:
+##### New Features
 
 * **NVSHAS-9776**: Add etcd toleration in helm chart.
 
-##### Bug Fixes:
+##### Bug Fixes
 
 * **NVSHAS-9507**: OCI container not getting scanned.
 * **NVSHAS-9787**: Remove unnecessary manager log.
@@ -85,7 +85,7 @@ See the [Security Advisory and CVEs](/security_advisories/security_advisories/cv
 
 #### 5.4.4 May 2025
 
-##### New Features:
+##### New Features
 
 * **NVSHAS-9915**: Show scan results from the Harbor scanner module in the NeuVector UI.
 * **NVSHAS-9904**: Expose `imagePullPolicy` to `values.yaml` for each component.
@@ -95,7 +95,7 @@ See the [Security Advisory and CVEs](/security_advisories/security_advisories/cv
 * **NVSHAS-8160**: [Controller] Adjust some items for Security Risk Score calculation.
 * **NVSHAS-4673**: Suggestion to add message before exporting groups.
 
-##### Bug Fixes:
+##### Bug Fixes
 
 * **NVSHAS-9931**: Add a warning if there are inconsistent versions of NeuVector products in multi-cluster.
 * **NVSHAS-9925**: `/v1/scan/asset/images` API on the Registry Page fails.
@@ -114,7 +114,7 @@ See the [Security Advisory and CVEs](/security_advisories/security_advisories/cv
 
 #### 5.4.3 March 2025
 
-##### New Features:
+##### New Features
 
 * **NVSHAS-9793**: Allow Fed Global roles in LDAP/userinitcfg when deploying NeuVector through the ConfigMap and Secret.
 * **NVSHAS-9764**: [RFE] Add support for Azure for "Remote Repository Configuration".
@@ -127,7 +127,7 @@ See the [Security Advisory and CVEs](/security_advisories/security_advisories/cv
 * **NVSHAS-7997**: Scanner connector for ghcr.io.
 * **NVSHAS-7982**: Assign WAF sensors from Federation Master.
 
-##### Bug Fixes:
+##### Bug Fixes
 
 * **NVSHAS-9849**: Enforcers not registering with controllers.
 * **NVSHAS-9847**: Wildcard filters not working for Docker registry.
@@ -154,7 +154,7 @@ See the [Security Advisory and CVEs](/security_advisories/security_advisories/cv
 
 #### 5.4.2 January 2025
 
-##### New Features:
+##### New Features
 
 * **NVSHAS-9726**: The monitor now passes proxy URL.
 * **NVSHAS-9719**: Announces the retirement of built-in certificates.
@@ -164,7 +164,7 @@ See the [Security Advisory and CVEs](/security_advisories/security_advisories/cv
 * **NVSHAS-9590**: Ability to choose which vulnerability score for all assets.
 * **NVSHAS-7555**: Include "Auto Refresh" option under Security Events.
 
-##### Bug Fixes:
+##### Bug Fixes
 
 * **NVSHAS-9662**: Inconsistent Role/RoleBinding logic in Helm chart 2.8.2.
 * **NVSHAS-9652**: Observed difference in syslog format in splunk.
@@ -317,7 +317,7 @@ Please note the stand-alone scanner will not be affected by these changes.
   + Cloud billing data archiving.
   + Namespace boundary enforcement.
 
-##### New Features:
+##### New Features
 
 + **NVSHAS-9012**: Displaying Rancher SSO users on NV UI that have the same user name.
 + **NVSHAS-8939**: Provide an option on NV UI so that Rancher SSO session users can drop the current JWT token (i.e. logout).
@@ -354,7 +354,7 @@ Please note the stand-alone scanner will not be affected by these changes.
 + **NVSHAS-7945**: (*Available when deployed from a Rancher Chart.*) Support DISA STIG benchmark for Kubernetes.
 + **NVSHAS-8234**: Admission Control Logic allowing images that should be denied.
 
-##### Bug Fixes:
+##### Bug Fixes
 
 + **NVSHAS-9005**: TypeError in registries: Cannot read properties of undefined (reading 'total_records').
 + **NVSHAS-9085**: Assets View PDF report shows 0% vulnerability even with present vulnerabilities.

--- a/versioned_docs/version-5.4/16.security_advisories/01.security_advisories/cve.md
+++ b/versioned_docs/version-5.4/16.security_advisories/01.security_advisories/cve.md
@@ -4,7 +4,7 @@ NeuVector is committed to informing the community of security issues. Below is a
 
 ## CVE List
 
-| ID | Description | Date | Resolution |
+| ID | Description | Date | Release |
 | :---- | :---- | :---- | :---- |
 | [CVE-2025-8077](https://github.com/neuvector/neuvector/security/advisories/GHSA-8pxw-9c75-6w56) | For NeuVector deployment on the Kubernetes-based environment, the bootstrap password of the default admin user will be generated randomly and stored in a Kubernetes secret. The default admin will need to get the bootstrap password from the Kubernetes secret first and will be asked to change password after the first UI login is successful. | 25 Aug 2025 | [NeuVector v5.4.6](https://github.com/neuvector/neuvector/releases/tag/v5.4.6) |
 | [CVE-2025-53884](https://github.com/neuvector/neuvector/security/advisories/GHSA-8ff6-pc43-jwv3) | NeuVector uses a cryptographically secure salt with the PBKDF2 algorithm instead of a simple hash to protect user passwords.For rolling upgrades from earlier versions, NeuVector recalculates and stores the new password hash only after each user’s next successful login. | 25 Aug 2025 | [NeuVector v5.4.6](https://github.com/neuvector/neuvector/releases/tag/v5.4.6) |


### PR DESCRIPTION
Adding v5.4.6 release note and updating the CVEs section to incorporate CVE list as well as security advisory information. Based on shared release note file.