### PR TITLE
Add OneTrust to ensure compliance

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -207,6 +207,20 @@ const config = {
         additionalLanguages: ['docker'],
       },
     }),
+  scripts: [
+    {
+      src: 'https://cdn.cookielaw.org/scripttemplates/otSDKStub.js',
+      type:'text/javascript',
+      charset: 'UTF-8',
+      'data-domain-script': '0f98beb0-fc4c-417d-a42e-564e2cae42d2',
+      async: true
+    },
+    {
+      src: '/scripts/optanonwrapper.js',
+      type:'text/javascript',
+      async: true
+    },
+  ],
 };
 
 export default config;

--- a/static/scripts/optanonwrapper.js
+++ b/static/scripts/optanonwrapper.js
@@ -1,0 +1,1 @@
+function OptanonWrapper() { }


### PR DESCRIPTION
Requested by SD-192521. 

> Since we have Google Analytics on the domain, it is necessary to implement OneTrust to ensure compliance.