### PR TITLE
Revise CONTRIBUTING.md for NeuVector Docs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,7 +4,7 @@ Thanks for your interest in improving the NeuVector documentation!
 
 ## About this repo
 
-This repository contains the source for the NeuVector documentation site,published at https://open-docs.neuvector.com. Content is written in Markdown and built with [Docusaurus](https://docusaurus.io/).
+This repository contains the source for the NeuVector documentation site, published at https://open-docs.neuvector.com. Documentation content lives as Markdown files under `docs/`. The site itself is built with [Docusaurus](https://docusaurus.io/).
 
 ## Getting started
 
@@ -34,15 +34,14 @@ If you find an error, gap, or outdated instruction in the docs, please open an i
 ## Making a change
 
 1. Fork the repo and create a branch for your change.
-2. Edit the relevant `.md` file under `docs/`.
-3. Preview locally with `yarn start` to confirm formatting and any admonitions (`:::note`, `:::warning`, etc.) render correctly.
-4. Open a pull request against `main`, describing what changed and why. If your change addresses an open issue, reference it (e.g. `Fixes #123`).
+2. Edit the relevant file under `docs/` — most content is plain Markdown (`.md`), though Docusaurus also supports `.mdx` for pages that embed
+   React components, so check the file extension before assuming Markdown syntax alone will apply.
+3. If your change applies to content that also exists in an older doc version (see `versioned_docs/`), consider whether that version needs
+   the same fix.
+4. Preview locally with `yarn start` to confirm formatting and any admonitions (`:::note`, `:::warning`, etc.) render correctly.
+5. Open a pull request against `main`, describing what changed and why.
 
-Pull requests should stay focused in scope — please avoid bundling unrelated
-changes into a single PR.
-
-**Important**: by submitting a patch, you agree to allow the project owner
-to license your work under the same license as used by this project.
+**Important**: by submitting a pull request, you agree to allow the project owner to license your work under the same license as used by this project.
 
 ## Questions
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,122 +1,49 @@
-# Contributing to Grav
+# Contributing to NeuVector Docs
 
-:+1::tada: First, thanks for getting involved with Grav! :tada::+1:
+Thanks for your interest in improving the NeuVector documentation!
 
-Please take a moment to review this document in order to make the contribution
-process easy and effective for everyone involved.
+## About this repo
 
-Following these guidelines helps to communicate that you respect the time of
-the developers managing and developing this open source project. In return,
-they should reciprocate that respect in addressing your issue or assessing
-patches and features.
+This repository contains the source for the NeuVector documentation site,published at https://open-docs.neuvector.com. Content is written in Markdown and built with [Docusaurus](https://docusaurus.io/).
 
-## Grav, Plugins, Themes and Skeletons
+## Getting started
 
-Grav is a large open source project—it's made up of over 100 repositories. When you initially consider contributing to Grav, you might be unsure about which of those 200 repositories implements the functionality you want to change or report a bug for.
+```shell
+git clone https://github.com/<your-fork>/docs.git
+cd docs
+yarn install
+yarn start
+```
 
-[https://github.com/getgrav/grav](https://github.com/getgrav/grav) is the main Grav repository. The core of Grav is provided by this repo.
+`yarn start` runs a local dev server with live reload, so you can preview your changes exactly as they'll render on the live site before submitting a PR.
 
-[https://github.com/getgrav/grav-plugin-admin](https://github.com/getgrav/grav-plugin-admin) is the Admin Plugin repository.
+To produce a static production build:
 
-Every Plugin and Theme has its own repository. If you have a problem you think is specific to a Theme or Plugin, please report it in its corresponding repository. Please read the Plugin or Theme documentation to ensure the problem is not addressed there already.
+```shell
+yarn build
+yarn serve   # preview the built output
+```
 
-Every Skeleton also has its own repository, so if an issue is not specific to a theme or plugin but rather to its usage in the skeleton, report it in the skeleton repository.
+## Reporting issues
 
-## Using the issue tracker
+If you find an error, gap, or outdated instruction in the docs, please open an issue describing:
+- The page/URL affected
+- What's currently wrong or unclear
+- What you'd expect instead
 
-The issue tracker is the preferred channel for [bug reports](#bugs),
-[features requests](#features) and [submitting pull
-requests](#pull-requests), but please respect the following restrictions:
+## Making a change
 
-* Please **do not** use the issue tracker for support requests. Use
-  [the Forum](http://getgrav.org/forum) or [the Gitter chat](https://gitter.im/getgrav/grav).
+1. Fork the repo and create a branch for your change.
+2. Edit the relevant `.md` file under `docs/`.
+3. Preview locally with `yarn start` to confirm formatting and any admonitions (`:::note`, `:::warning`, etc.) render correctly.
+4. Open a pull request against `main`, describing what changed and why. If your change addresses an open issue, reference it (e.g. `Fixes #123`).
 
+Pull requests should stay focused in scope — please avoid bundling unrelated
+changes into a single PR.
 
-<a name="bugs"></a>
-## Bug reports
+**Important**: by submitting a patch, you agree to allow the project owner
+to license your work under the same license as used by this project.
 
-A bug is a _demonstrable problem_ that is caused by the code in the repository.
-Good bug reports are extremely helpful - thank you!
+## Questions
 
-Guidelines for bug reports:
-
-1. **Check you satisfy the Grav requirements** &mdash; [http://learn.getgrav.org/basics/requirements](http://learn.getgrav.org/basics/requirements)
-
-2. **Check this happens on a clean Grav install** &mdash; check if the issue happens on any Grav site, or just with a specific configuration of plugins / theme
-
-3. **Use the GitHub issue search** &mdash; check if the issue has already been
-   reported.
-
-4. **Check if the issue is already being solved in a PR** &mdash; check the open Pull Requests to see if one already solves the problem you're having
-
-5. **Check if the issue has been fixed** &mdash; try to reproduce it using the
-   latest `develop` branch in the repository.
-
-6. **Isolate the problem** &mdash; create a [reduced test
-   case](http://css-tricks.com/reduced-test-cases/) and provide a step-by-step instruction set on how to recreate the problem. Include code samples, page snippets or yaml configurations if needed.
-
-A good bug report shouldn't leave others needing to chase you up for more
-information. Please try to be as detailed as possible in your report.
-
-What is your environment? Is it localhost, OSX, Linux, on a remote server? Same happening locally and or the server, or just locally or just on Linux?
-
-What steps will reproduce the issue? What browser(s) and OS experience the problem?
-
-What would you expect to be the outcome?
-
-Did the problem start happening recently (e.g. after updating to a new version of Grav) or was this always a problem?
-
-If the problem started happening recently, can you reproduce the problem in an older version of Grav? What's the most recent version in which the problem doesn't happen? You can download older versions of Grav from the releases page on Github.
-
-Can you reliably reproduce the issue? If not, provide details about how often the problem happens and under which conditions it normally happens.
-
-
-All these details will help people to fix any potential bugs.
-
-Important: [include Code Samples in triple backticks](https://help.github.com/articles/github-flavored-markdown/#fenced-code-blocks) so that Github will provide a proper indentation. [Add the language name after the backticks](https://help.github.com/articles/github-flavored-markdown/#syntax-highlighting) to add syntax highlighting to the code snippets.
-
-Example:
-
-> Short and descriptive example bug report title
->
-> A summary of the issue and the browser/OS environment in which it occurs. If
-> suitable, include the steps required to reproduce the bug.
->
-> 1. This is the first step
-> 2. This is the second step
-> 3. Further steps, etc.
->>
-> Any other information you want to share that is relevant to the issue being
-> reported. This might include the lines of code that you have identified as
-> causing the bug, and potential solutions (and your opinions on their
-> merits).
-
-
-<a name="features"></a>
-## Feature requests
-
-Feature requests are welcome. But take a moment to find out whether your idea
-fits with the scope and aims of the project. It's up to *you* to make a strong
-case to convince the project's developers of the merits of this feature. Please
-provide as much detail and context as possible.
-
-
-<a name="pull-requests"></a>
-## Pull requests
-
-Good pull requests - patches, improvements, new features - are a fantastic
-help. They should remain focused in scope and avoid containing unrelated
-commits.
-
-**Please ask first** in Gitter or in the Forum before embarking on any significant pull request (e.g.
-implementing features, refactoring code..),
-otherwise you risk spending a lot of time working on something that the
-project's developers might not want to merge into the project.
-
-Please adhere to the coding conventions used throughout the project (indentation,
-accurate comments, etc.) and any other requirements.
-
-See [Using Pull Request](https://help.github.com/articles/using-pull-requests/) and [Fork a Repo](https://help.github.com/articles/fork-a-repo/) if you're not familiar with Pull Requests.
-
-**IMPORTANT**: By submitting a patch, you agree to allow the project owner to
-license your work under the same license as that used by the project.
+For anything not covered here, feel free to open an issue.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,20 +4,38 @@ Thanks for your interest in improving the NeuVector documentation!
 
 ## About this repo
 
-This repository contains the source for the NeuVector documentation site, published at https://open-docs.neuvector.com. Documentation content lives as Markdown files under `docs/`. The site itself is built with [Docusaurus](https://docusaurus.io/).
+This repository contains the source code for the official [NeuVector documentation site](https://open-docs.neuvector.com). The documentation content is written in Markdown and the site is statically generated using [Docusaurus](https://docusaurus.io/).
 
 ## Getting started
+## Get started
 
-```shell
-git clone https://github.com/<your-fork>/docs.git
-cd docs
-yarn install
-yarn start
-```
+To preview your changes locally, install the following tools:
 
-`yarn start` runs a local dev server with live reload, so you can preview your changes exactly as they'll render on the live site before submitting a PR.
+* [Node.js](https://nodejs.org/)
+* [Yarn](https://yarnpkg.com/)
 
-To produce a static production build:
+1. Fork the repository to your GitHub account, then clone your fork and navigate to the `docs` directory.
+
+   ```shell
+   git clone https://github.com/<your-fork>/docs.git
+   cd docs
+   ```
+
+2. Install the project dependencies.
+
+   ```shell
+   yarn install
+   ```
+
+3. Start the local development server.
+
+   ```shell
+   yarn start
+   ```
+
+`yarn start` launches a local development server (usually at http://localhost:3000) with live reload enabled. This allows you to preview your changes exactly as they will render on the live site before you submit a Pull Request.
+
+If you need to test the static production build locally to ensure everything compiles correctly:
 
 ```shell
 yarn build
@@ -26,23 +44,27 @@ yarn serve   # preview the built output
 
 ## Reporting issues
 
-If you find an error, gap, or outdated instruction in the docs, please open an issue describing:
-- The page/URL affected
-- What's currently wrong or unclear
-- What you'd expect instead
+If you find a typo, an error, a gap in the documentation, or an outdated instruction, please open an issue.
+
+To help us resolve the issue quickly, please include:
+
+- The URL or file path of the affected page.
+- A description of what is currently wrong or unclear.
+- What you would expect to see instead.
 
 ## Making a change
 
-1. Fork the repo and create a branch for your change.
-2. Edit the relevant file under `docs/` — most content is plain Markdown (`.md`), though Docusaurus also supports `.mdx` for pages that embed
-   React components, so check the file extension before assuming Markdown syntax alone will apply.
-3. If your change applies to content that also exists in an older doc version (see `versioned_docs/`), consider whether that version needs
-   the same fix.
-4. Preview locally with `yarn start` to confirm formatting and any admonitions (`:::note`, `:::warning`, etc.) render correctly.
-5. Open a pull request against `main`, describing what changed and why.
+When you are ready to contribute a fix or an update, follow these steps:
+
+1. Create a branch: Create a new branch on your fork for your changes (e.g., `git checkout -b fix/typo-in-getting-started`).
+2. Edit the content: Make your changes to the relevant files under the docs/ directory.
+   * Most content is plain Markdown (.md), but Docusaurus also supports `.mdx` for pages that embed React components. Be sure to check the file extension before assuming standard Markdown syntax alone will apply.
+3. Check older versions: If your change applies to content that also exists in an older documentation version (found in the `versioned_docs`/ directory), please consider applying the same fix to those versions.
+4. Preview locally: Use `yarn start` to verify that your formatting for Docusaurus-specific admonitions like `:::note`, `:::warning`, and `:::info—renders` correctly.
+5. Submit a Pull Request: Open a Pull Request against the `main` branch. Provide a clear and concise description of what was changed and why.
 
 **Important**: by submitting a pull request, you agree to allow the project owner to license your work under the same license as used by this project.
 
 ## Questions
 
-For anything not covered here, feel free to open an issue.
+For anything not covered here, or if you need assistance with your contribution, please feel free to open an issue. We are here to help!


### PR DESCRIPTION
## Description
Fix #256

Replaces CONTRIBUTING.md, which is leftover boilerplate from the Grav project (references getgrav/grav, Gitter, Grav-specific requirements) and doesn't apply to this repo. New content covers actual setup (`yarn install`, `yarn start`), how to make a change, and how to report issues, based on what's in README.md.

This is a starting draft to replace outdated content that referenced an unrelated project — happy to adjust based on the maintainer's actual preferred process (e.g. CLA, review expectations) if different from what's proposed here.

## Test
Docs-only change.

## Additional Information
### Tradeoff
Kept this factual and minimal, happy to expand if there's an existing process I should reflect.

### Potential improvement
Could add a PR template or issue template once contribution volume picks up.