### PR TITLE
issue-2616: update doc page for the new default mode of 'new service profile baseline'

### DIFF
--- a/docs/05.policy/06.processrules/06.processrules.md
+++ b/docs/05.policy/06.processrules/06.processrules.md
@@ -15,7 +15,7 @@ There is a limitation when running on systems with the AUFS file system, whereby
 
 #### Zero-drift Process Protection
 
-This is the default mode for process and file protections. Zero-drift automatically allows only processes which originate from the parent process that is in the original container image, and does not allow file updates or new files to be installed. When in Discover or Monitor mode, zero-drift will alert on any suspicious process or file activity. In Protect mode, it will block such activity. Zero-drift does not require processes to be learned or added to an allow-list. Disabling zero-drift for a group will cause the process and file rules listed for the group to take effect instead.
+This is the default mode for process and file protections in NeuVector 5.6.0 and older versions. Zero-drift automatically allows only processes which originate from the parent process that is in the original container image, and does not allow file updates or new files to be installed. When in Discover or Monitor mode, zero-drift will alert on any suspicious process or file activity. In Protect mode, it will block such activity. Zero-drift does not require processes to be learned or added to an allow-list. Disabling zero-drift for a group will cause the process and file rules listed for the group to take effect instead.
 
 :::note
 (1) The process/file rules listed for each group are always applied, even when zero-drift is enabled. This offers a way to add allow/deny exceptions to the base zero-drift protections. Keep in mind that if a group starts in Discover mode, process/file rules can be automatically added to the list, and should be reviewed and edited before moving to Monitor/Protect modes.
@@ -27,7 +27,7 @@ The ability to enable/disable zero-drift mode is in the console in Policy -> Gro
 
 #### Basic Mode Process Protection
 
-Zero-drift can be disabled, switching to Basic process protection. Basic protection enforces process/file activity based on the listed process and/or file rules for each Group. This means that there must be a list of process rules and/or file rules in place for protection to occur. Rules can be auto-created through Behavioral Learning while in Discover mode, manually created through the console or rest API, or programmatically created by applying a CRD. With Basic enabled if there are no rules in place, all activity will be alerted/blocked while in Monitor or Protect modes.
+Starting from NeuVector 5.6.1, this is the default mode for process and file protections in new deployment. Zero-drift can be disabled, switching to Basic process protection. Basic protection enforces process/file activity based on the listed process and/or file rules for each Group. This means that there must be a list of process rules and/or file rules in place for protection to occur. Rules can be auto-created through Behavioral Learning while in Discover mode, manually created through the console or rest API, or programmatically created by applying a CRD. With Basic enabled if there are no rules in place, all activity will be alerted/blocked while in Monitor or Protect modes.
 
 #### Behavioral Learning Based Process Protection
 

--- a/versioned_docs/version-5.6/05.policy/06.processrules/06.processrules.md
+++ b/versioned_docs/version-5.6/05.policy/06.processrules/06.processrules.md
@@ -15,7 +15,7 @@ There is a limitation when running on systems with the AUFS file system, whereby
 
 #### Zero-drift Process Protection
 
-This is the default mode for process and file protections. Zero-drift automatically allows only processes which originate from the parent process that is in the original container image, and does not allow file updates or new files to be installed. When in Discover or Monitor mode, zero-drift will alert on any suspicious process or file activity. In Protect mode, it will block such activity. Zero-drift does not require processes to be learned or added to an allow-list. Disabling zero-drift for a group will cause the process and file rules listed for the group to take effect instead.
+This is the default mode for process and file protections in NeuVector 5.6.0 and older versions. Zero-drift automatically allows only processes which originate from the parent process that is in the original container image, and does not allow file updates or new files to be installed. When in Discover or Monitor mode, zero-drift will alert on any suspicious process or file activity. In Protect mode, it will block such activity. Zero-drift does not require processes to be learned or added to an allow-list. Disabling zero-drift for a group will cause the process and file rules listed for the group to take effect instead.
 
 :::note
 (1) The process/file rules listed for each group are always applied, even when zero-drift is enabled. This offers a way to add allow/deny exceptions to the base zero-drift protections. Keep in mind that if a group starts in Discover mode, process/file rules can be automatically added to the list, and should be reviewed and edited before moving to Monitor/Protect modes.
@@ -27,7 +27,7 @@ The ability to enable/disable zero-drift mode is in the console in Policy -> Gro
 
 #### Basic Mode Process Protection
 
-Zero-drift can be disabled, switching to Basic process protection. Basic protection enforces process/file activity based on the listed process and/or file rules for each Group. This means that there must be a list of process rules and/or file rules in place for protection to occur. Rules can be auto-created through Behavioral Learning while in Discover mode, manually created through the console or rest API, or programmatically created by applying a CRD. With Basic enabled if there are no rules in place, all activity will be alerted/blocked while in Monitor or Protect modes.
+Starting from NeuVector 5.6.1, this is the default mode for process and file protections in new deployment. Zero-drift can be disabled, switching to Basic process protection. Basic protection enforces process/file activity based on the listed process and/or file rules for each Group. This means that there must be a list of process rules and/or file rules in place for protection to occur. Rules can be auto-created through Behavioral Learning while in Discover mode, manually created through the console or rest API, or programmatically created by applying a CRD. With Basic enabled if there are no rules in place, all activity will be alerted/blocked while in Monitor or Protect modes.
 
 #### Behavioral Learning Based Process Protection
 


### PR DESCRIPTION
## Description

Fix https://github.com/neuvector/neuvector/issues/2616

Starting from NV 5.6.1,  the default mode of 'new service profile baseline' is Basic in new deployment

## Test

## Additional Information

### Tradeoff

### Potential improvement

