### PR TITLE
docs: add description for MATCH_PROXYMESH_PARENT_POLICY

### DIFF
--- a/docs/02.deploying/01.production/03.details/03.details.md
+++ b/docs/02.deploying/01.production/03.details/03.details.md
@@ -113,6 +113,8 @@ This environment variable is only for the standalone NeuVector product. Please s
 * NV_SYSTEM_GROUPS
 > (Optional) Specify what groups or namespaces that NeuVector considers to be 'system containers', separated by semi-colons. For example, for Rancher-based apps and the default namespace, NV_SYSTEM_GROUPS=*cattle-system;*default. These values are translated in regex. System containers (which also include NeuVector and Kubernetes system containers) operate only in Monitor mode (alert only) even if the group is set to Protect mode.
 
+* MATCH_PROXYMESH_PARENT_POLICY
+> (Optional) Set the value to "1" to match Istio proxymesh traffic against the parent workload's network policy. Disabled by default. When enabled, proxymesh traffic tapped on the loopback interface uses the parent workload policy handle instead of the proxymesh endpoint, so connections can correctly match parent allow/deny rules. When XFF is enabled and the destination is loopback, the destination is rewritten to the parent workload IPs for policy lookup.
 
 ### Open Ports
 

--- a/versioned_docs/version-5.6/02.deploying/01.production/03.details/03.details.md
+++ b/versioned_docs/version-5.6/02.deploying/01.production/03.details/03.details.md
@@ -113,6 +113,8 @@ This environment variable is only for the standalone NeuVector product. Please s
 * NV_SYSTEM_GROUPS
 > (Optional) Specify what groups or namespaces that NeuVector considers to be 'system containers', separated by semi-colons. For example, for Rancher-based apps and the default namespace, NV_SYSTEM_GROUPS=*cattle-system;*default. These values are translated in regex. System containers (which also include NeuVector and Kubernetes system containers) operate only in Monitor mode (alert only) even if the group is set to Protect mode.
 
+* MATCH_PROXYMESH_PARENT_POLICY
+> (Optional) Set the value to "1" to match Istio proxymesh traffic against the parent workload's network policy. Disabled by default. When enabled, proxymesh traffic tapped on the loopback interface uses the parent workload policy handle instead of the proxymesh endpoint, so connections can correctly match parent allow/deny rules. When XFF is enabled and the destination is loopback, the destination is rewritten to the parent workload IPs for policy lookup.
 
 ### Open Ports
 


### PR DESCRIPTION
## Description

<!-- Please provide the link to the GitHub issue you are addressing -->

Fix https://github.com/neuvector/neuvector/issues/2694
We introduced a new environment variable MATCH_PROXYMESH_PARENT_POLICY which can allow user to match Istio proxymesh traffic against the parent workload's network policy.

<!-- Please provide the link to the documentation related to your change, if applicable -->
<!-- [Documentation](https://<insert your url>) -->

## Test

<!-- Please provides a short description about how to test your pullrequest -->

To test this pull request, you can run the following commands:

<!--
```shell
cp <to_package_directory>
go test
```
-->

## Additional Information

### Tradeoff

<!-- Please describe, if any, the tradeoffs that you found acceptable in this pull request -->

### Potential improvement

<!-- Please describe, if any, potential improvement that you are envisioning -->
