### PR TITLE
add Cacerts example in configmap

### DIFF
--- a/docs/02.deploying/01.production/01.configmap/01.configmap.md
+++ b/docs/02.deploying/01.production/01.configmap/01.configmap.md
@@ -13,7 +13,7 @@ The 'always_reload: true' setting can be added in any ConfigMap yaml to force re
 
 #### Complete Sample NeuVector ConfigMap (initcfg.yaml)
 
-The latest ConfigMap can be found at the following [initcfg.yaml file](https://raw.githubusercontent.com/neuvector/manifests/main/kubernetes/5.4.0/initcfg.yaml).
+The latest ConfigMap can be found at the following [initcfg.yaml file](https://raw.githubusercontent.com/neuvector/manifests/main/kubernetes/latest/initcfg.yaml).
 
 The sample is also shown below. This contains all the settings available. Please remove the sections not needed and edit the sections needed. Note: If using configmap in a secret, see section below for formatting changes.
 
@@ -393,6 +393,22 @@ data:
       Auto_Scan: false
     # Optional. default value is 24. unit is hour and range is between 0 and 168
     Unused_Group_Aging: 24
+    # Optional. Enable TLS verification for communications to LDAP/OIDC/webhook/registry servers. Enabled by default for new deployment
+    Enable_Tls_Verification: true
+    # Optional. TLS self-signed certificate context when TLS verification is enabled
+    Cacerts:
+        - |
+          -----BEGIN CERTIFICATE-----
+          ..................
+          ..................
+          ........
+          -----END CERTIFICATE-----
+        - |
+          -----BEGIN CERTIFICATE-----
+          ..................
+          ..................
+          ........
+          -----END CERTIFICATE-----
   userinitcfg.yaml: |
     # Optional. true or false or empty string(false)
     always_reload: false

--- a/versioned_docs/version-5.5/02.deploying/01.production/01.configmap/01.configmap.md
+++ b/versioned_docs/version-5.5/02.deploying/01.production/01.configmap/01.configmap.md
@@ -13,7 +13,7 @@ The 'always_reload: true' setting can be added in any ConfigMap yaml to force re
 
 #### Complete Sample NeuVector ConfigMap (initcfg.yaml)
 
-The latest ConfigMap can be found at the following [initcfg.yaml file](https://raw.githubusercontent.com/neuvector/manifests/main/kubernetes/5.4.0/initcfg.yaml).
+The latest ConfigMap can be found at the following [initcfg.yaml file](https://raw.githubusercontent.com/neuvector/manifests/main/kubernetes/5.5.0/initcfg.yaml).
 
 The sample is also shown below. This contains all the settings available. Please remove the sections not needed and edit the sections needed. Note: If using configmap in a secret, see section below for formatting changes.
 
@@ -393,6 +393,22 @@ data:
       Auto_Scan: false
     # Optional. default value is 24. unit is hour and range is between 0 and 168
     Unused_Group_Aging: 24
+    # Optional. Enable TLS verification for communications to LDAP/OIDC/webhook/registry servers. Enabled by default for new deployment
+    Enable_Tls_Verification: true
+    # Optional. TLS self-signed certificate context when TLS verification is enabled
+    Cacerts:
+        - |
+          -----BEGIN CERTIFICATE-----
+          ..................
+          ..................
+          ........
+          -----END CERTIFICATE-----
+        - |
+          -----BEGIN CERTIFICATE-----
+          ..................
+          ..................
+          ........
+          -----END CERTIFICATE-----
   userinitcfg.yaml: |
     # Optional. true or false or empty string(false)
     always_reload: false

--- a/versioned_docs/version-5.6/02.deploying/01.production/01.configmap/01.configmap.md
+++ b/versioned_docs/version-5.6/02.deploying/01.production/01.configmap/01.configmap.md
@@ -13,7 +13,7 @@ The 'always_reload: true' setting can be added in any ConfigMap yaml to force re
 
 #### Complete Sample NeuVector ConfigMap (initcfg.yaml)
 
-The latest ConfigMap can be found at the following [initcfg.yaml file](https://raw.githubusercontent.com/neuvector/manifests/main/kubernetes/5.4.0/initcfg.yaml).
+The latest ConfigMap can be found at the following [initcfg.yaml file](https://raw.githubusercontent.com/neuvector/manifests/main/kubernetes/5.6.0/initcfg.yaml).
 
 The sample is also shown below. This contains all the settings available. Please remove the sections not needed and edit the sections needed. Note: If using configmap in a secret, see section below for formatting changes.
 
@@ -393,6 +393,22 @@ data:
       Auto_Scan: false
     # Optional. default value is 24. unit is hour and range is between 0 and 168
     Unused_Group_Aging: 24
+    # Optional. Enable TLS verification for communications to LDAP/OIDC/webhook/registry servers. Enabled by default for new deployment
+    Enable_Tls_Verification: true
+    # Optional. TLS self-signed certificate context when TLS verification is enabled
+    Cacerts:
+        - |
+          -----BEGIN CERTIFICATE-----
+          ..................
+          ..................
+          ........
+          -----END CERTIFICATE-----
+        - |
+          -----BEGIN CERTIFICATE-----
+          ..................
+          ..................
+          ........
+          -----END CERTIFICATE-----
   userinitcfg.yaml: |
     # Optional. true or false or empty string(false)
     always_reload: false


### PR DESCRIPTION
## Description

1. Add example for configuring `Cacerts` in sysinitcfg.yaml  (UI: Settings -> Configuration -> TLS self-signed certificate context)
2. For different NV versions, use different links to initcfg.yaml in case some new settings are available only in newer version(s)

## Test

To test this pull request, you can run the following commands:

## Additional Information

### Tradeoff

### Potential improvement

