### PR TITLE
chore: update codeowner to use team instead of single user

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,1 @@
-* @kakabisht
+* @neuvector/docs


### PR DESCRIPTION
Using user instead of team in CODEOWNER is a pain to maintain